### PR TITLE
fix(memory): entry-level truncation in memory snapshot

### DIFF
--- a/bot/src/memory/layout.ts
+++ b/bot/src/memory/layout.ts
@@ -24,6 +24,8 @@ export const INDEX_HEADING = "## Index";
 
 // Hard cap for the memory block injected into the system prompt. ~4 chars/token
 // gives roughly 1500 tokens — fits comfortably alongside the identity prompt.
+// NOTE: 4 chars/token is an approximation; non-English text (especially CJK/Russian
+// characters) may encode at 2–3 chars/token, so actual token count varies.
 export const MEMORY_PROMPT_CHAR_CAP = 6000;
 
 // Lint thresholds (conservative defaults; tune once we have real sessions).

--- a/bot/src/memory/session_loader.ts
+++ b/bot/src/memory/session_loader.ts
@@ -34,9 +34,25 @@ import MEMORY_PROMPT_MD from "./memory_prompt.md?raw";
 
 function truncateToCap(content: string, cap: number): string {
 	if (content.length <= cap) return content;
-	const suffix =
-		"\n\n... [memory snapshot truncated — call memory_lint or compact via rotate_actuel]";
-	return content.slice(0, Math.max(0, cap - suffix.length)) + suffix;
+
+	// Split by newlines and accumulate line-by-line, never slicing mid-line.
+	const lines = content.split("\n");
+	const result: string[] = [];
+	let total = 0;
+
+	for (const line of lines) {
+		const withSeparator = result.length > 0 ? line.length + 1 : line.length;
+		if (total + withSeparator <= cap) {
+			result.push(line);
+			total += withSeparator;
+		} else {
+			break;
+		}
+	}
+
+	const overflow = lines.length - result.length;
+	const suffix = `\n\n... [+${overflow} more entries — use grep to retrieve specific topics]`;
+	return result.join("\n") + suffix;
 }
 
 export async function composeMemorySnapshot(


### PR DESCRIPTION
Replace character-level truncateToCap() with entry-level truncation that never slices mid-line.

Changes:
- bot/src/memory/session_loader.ts: New truncateToCap() splits by newlines and accumulates line-by-line
- bot/src/memory/layout.ts: Added note about 4-char/token heuristic approximation for non-English (CJK/Russian)

Note: Could not run bun tests (bun not available in environment).