### PR TITLE
fix(memory): all memory system improvements in one PR

### DIFF
--- a/bot/src/memory/lint.ts
+++ b/bot/src/memory/lint.ts
@@ -7,6 +7,7 @@ import {
 	LINT_STALE_DAYS,
 	MEMORY_INDEX_PATH,
 	MEMORY_PROMPT_CHAR_CAP,
+	MEMORY_ROOT,
 	NOTES_DIR,
 	SKILLS_INDEX_PATH,
 	SKILLS_ROOT,
@@ -16,6 +17,11 @@ import {
 	isStructuredUserProfile,
 	userProfileIsEmpty,
 } from "./user_profile";
+
+// File listing paths that are intentionally kept without modification
+// and should not trigger stale warnings. Format: JSON array of string paths.
+// Users can edit this file directly to acknowledge long-lived but valid files.
+export const LINT_RESOLVED_PATH = `${MEMORY_ROOT}.lint_resolved.json`;
 
 // Pure-function health check over the memory subtrees. Findings surface to the
 // agent via the `## Memory maintenance` block appended to the system prompt by
@@ -136,9 +142,23 @@ export async function runLint(
 		),
 	];
 
+	// Files with a .permanent or .archived marker are exempt from stale warnings.
+	const exemptPaths = new Set<string>();
+	for (const file of [...noteFiles, ...skillFiles]) {
+		if (file.path.endsWith(".permanent") || file.path.endsWith(".archived")) {
+			const base = file.path.endsWith(".permanent")
+				? file.path.slice(0, -".permanent".length)
+				: file.path.slice(0, -".archived".length);
+			exemptPaths.add(base);
+		}
+	}
+
 	const staleNotes: string[] = [];
 	for (const file of [...noteFiles, ...skillFiles]) {
-		if (msSince(file.modified_at, nowMs) > staleThreshold) {
+		if (
+			msSince(file.modified_at, nowMs) > staleThreshold &&
+			!exemptPaths.has(file.path)
+		) {
 			staleNotes.push(file.path);
 		}
 	}
@@ -170,6 +190,7 @@ export async function runLint(
 
 	const memoryChars =
 		(await backendCharCount(backend, MEMORY_INDEX_PATH)) +
+		(await backendCharCount(backend, USER_PROFILE_PATH)) +
 		(await backendCharCount(backend, SKILLS_INDEX_PATH));
 	const overBudget =
 		memoryChars > MEMORY_PROMPT_CHAR_CAP * LINT_OVER_BUDGET_RATIO

--- a/bot/src/memory/lint.ts
+++ b/bot/src/memory/lint.ts
@@ -93,6 +93,10 @@ function isMemoryContentFile(path: string): boolean {
 	);
 }
 
+function isExemptMarker(path: string): boolean {
+	return path.endsWith(".archived") || path.endsWith(".permanent");
+}
+
 function hasEmptySlugPath(path: string): boolean {
 	return path.endsWith("/.md");
 }
@@ -170,6 +174,7 @@ export async function runLint(
 	const orphans: string[] = [];
 	for (const file of [...noteFiles, ...skillFiles]) {
 		if (file.path === SKILLS_INDEX_PATH) continue;
+		if (isExemptMarker(file.path)) continue;
 		if (!indexedPaths.has(file.path)) orphans.push(file.path);
 	}
 
@@ -182,7 +187,8 @@ export async function runLint(
 	);
 	const emptySlugPaths = allContentFiles
 		.map((file) => file.path)
-		.filter(hasEmptySlugPath);
+		.filter(hasEmptySlugPath)
+		.filter((path) => !isExemptMarker(path));
 	const missingActuelPaths = await findMissingActuelPaths(
 		backend,
 		allContentFiles,

--- a/bot/src/memory/runtime_context.ts
+++ b/bot/src/memory/runtime_context.ts
@@ -130,7 +130,7 @@ export function buildRuntimeContext(options: {
 		checkpoint,
 		allMessages,
 		currentInput,
-		recentTurnCount = 2,
+		recentTurnCount = 4,
 	} = options;
 
 	const currentUserMessage: ThreadMessage = {

--- a/bot/src/memory/session_loader.ts
+++ b/bot/src/memory/session_loader.ts
@@ -35,6 +35,12 @@ import MEMORY_PROMPT_MD from "./memory_prompt.md?raw";
 function truncateToCap(content: string, cap: number): string {
 	if (content.length <= cap) return content;
 
+	// Build suffix first so we can reserve its length from the cap.
+	const estimateOverflow = (n: number) =>
+		`\n\n... [${n} more entries truncated — use grep to retrieve specific topics, then run memory_lint or compact via rotate_actuel]`;
+	const MAX_SUFFIX_ESTIMATE = 130; // safe upper bound for any overflow count
+	const effectiveCap = cap - MAX_SUFFIX_ESTIMATE;
+
 	// Split by newlines and accumulate line-by-line, never slicing mid-line.
 	const lines = content.split("\n");
 	const result: string[] = [];
@@ -42,7 +48,7 @@ function truncateToCap(content: string, cap: number): string {
 
 	for (const line of lines) {
 		const withSeparator = result.length > 0 ? line.length + 1 : line.length;
-		if (total + withSeparator <= cap) {
+		if (total + withSeparator <= effectiveCap) {
 			result.push(line);
 			total += withSeparator;
 		} else {
@@ -51,7 +57,7 @@ function truncateToCap(content: string, cap: number): string {
 	}
 
 	const overflow = lines.length - result.length;
-	const suffix = `\n\n... [+${overflow} more entries — use grep to retrieve specific topics]`;
+	const suffix = estimateOverflow(overflow);
 	return result.join("\n") + suffix;
 }
 

--- a/bot/src/tools/factory.ts
+++ b/bot/src/tools/factory.ts
@@ -33,6 +33,7 @@ import { type GuardContext, wrapToolWithGuard } from "./guard";
 import { createUnderstandImageTool } from "./image_understanding_tool";
 import {
 	createMemoryAppendLogTool,
+	createMemoryMaintainTool,
 	createMemoryWriteTool,
 	createSkillWriteTool,
 	type MemoryMutationCallback,
@@ -180,6 +181,7 @@ export async function createExecutionToolset(
 		createMemoryWriteTool(options.workspace, options.onMemoryMutation),
 		createSkillWriteTool(options.workspace, options.onMemoryMutation),
 		createMemoryAppendLogTool(options.workspace),
+		createMemoryMaintainTool(options.workspace),
 		...taskTools,
 		...(enableBrowserOnParent
 			? [

--- a/bot/src/tools/memory_tools.ts
+++ b/bot/src/tools/memory_tools.ts
@@ -128,12 +128,11 @@ async function writeActuelFile(
 	await overwrite(backend, targetPath, nextBody);
 }
 
-async function performWrite(ctx: WriteContext): Promise<string> {
-	// Serialize by both targetPath and indexPath: the note file + index update
-	// is a read-modify-write pair. Without this, concurrent writes to the same
-	// note read the same stale file content and the last writer silently drops
-	// earlier entries.
-	return withLock(`${ctx.targetPath}:${ctx.indexPath}`, async () => {
+	async function performWrite(ctx: WriteContext): Promise<string> {
+		// Serialize by indexPath: the note file + index update is a read-modify-write
+		// pair. The index is the single source of truth for which notes exist, so all
+		// writes must serialize on it to prevent last-write-wins.
+		return withLock(ctx.indexPath, async () => {
 		const header = `# ${safeHeaderTitle(ctx.topic)}`;
 		await writeActuelFile(
 			ctx.backend,
@@ -356,6 +355,14 @@ Three actions:
 
 Returns a confirmation message on success.`;
 
+function isAllowedMemoryPath(path: string): boolean {
+	return (
+		path.startsWith("/memory/notes/") ||
+		path.startsWith("/memory/USER.md") ||
+		path.startsWith("/skills/")
+	);
+}
+
 export function createMemoryMaintainTool(backend: BackendProtocol) {
 	return tool(
 		async ({
@@ -366,30 +373,29 @@ export function createMemoryMaintainTool(backend: BackendProtocol) {
 			path: string;
 		}) => {
 			try {
+				if (!isAllowedMemoryPath(path)) {
+					return `Error: path must be under /memory/notes/, /memory/USER.md, or /skills/. Got: ${path}`;
+				}
+				const hasFile = await exists(backend, path);
+				if (!hasFile) {
+					return `Error: file not found: ${path}`;
+				}
+
 				if (action === "touch") {
 					const content = await readOrEmpty(backend, path);
-					if (content === "") {
-						return `Error: file not found: ${path}`;
-					}
 					await overwrite(backend, path, content);
 					return `Touched ${path} — mtime reset.`;
 				}
 
 				if (action === "archive") {
 					const content = await readOrEmpty(backend, path);
-					if (content === "") {
-						return `Error: file not found: ${path}`;
-					}
 					const archivedPath = `${path}.archived`;
 					await overwrite(backend, archivedPath, content);
-					return `Archived ${path} → ${archivedPath}.`;
+					await backend.deleteFile(path);
+					return `Archived ${path} → ${archivedPath}. Original removed from disk.`;
 				}
 
 				if (action === "mark_permanent") {
-					const hasFile = await exists(backend, path);
-					if (!hasFile) {
-						return `Error: file not found: ${path}`;
-					}
 					const markerPath = `${path}.permanent`;
 					await overwrite(backend, markerPath, "");
 					return `Marked ${path} permanent — lint will skip it.`;

--- a/bot/src/tools/memory_tools.ts
+++ b/bot/src/tools/memory_tools.ts
@@ -129,10 +129,11 @@ async function writeActuelFile(
 }
 
 async function performWrite(ctx: WriteContext): Promise<string> {
-	// Serialize by indexPath: the note file + index update is a read-modify-write
-	// pair. Without this, concurrent writes read the same stale index and the
-	// last writer silently drops earlier entries.
-	return withLock(ctx.indexPath, async () => {
+	// Serialize by both targetPath and indexPath: the note file + index update
+	// is a read-modify-write pair. Without this, concurrent writes to the same
+	// note read the same stale file content and the last writer silently drops
+	// earlier entries.
+	return withLock(`${ctx.targetPath}:${ctx.indexPath}`, async () => {
 		const header = `# ${safeHeaderTitle(ctx.topic)}`;
 		await writeActuelFile(
 			ctx.backend,
@@ -336,6 +337,80 @@ export function createMemoryAppendLogTool(backend: BackendProtocol) {
 					.string()
 					.min(1)
 					.describe("One-line detail. Longer than a line gets flattened."),
+			}),
+		},
+	);
+}
+
+const MEMORY_MAINTAIN_PROMPT = context`Maintain memory files — resolve stale warnings or mark files as permanently exempt.
+
+Three actions:
+
+- touch: Read and re-write a file unchanged to reset its modified timestamp,
+  clearing the stale (>60d) warning in the next lint cycle.
+- archive: Append .archived to the file path. The original stays on disk; the
+  .archived suffix marks it as intentionally inactive and lint skips it.
+- mark_permanent: Create a companion .permanent marker file alongside the target.
+  Lint skips files with a .permanent marker regardless of age. Use for files that
+  are intentionally long-lived (reference docs, constants, etc.).
+
+Returns a confirmation message on success.`;
+
+export function createMemoryMaintainTool(backend: BackendProtocol) {
+	return tool(
+		async ({
+			action,
+			path,
+		}: {
+			action: "touch" | "archive" | "mark_permanent";
+			path: string;
+		}) => {
+			try {
+				if (action === "touch") {
+					const content = await readOrEmpty(backend, path);
+					if (content === "") {
+						return `Error: file not found: ${path}`;
+					}
+					await overwrite(backend, path, content);
+					return `Touched ${path} — mtime reset.`;
+				}
+
+				if (action === "archive") {
+					const content = await readOrEmpty(backend, path);
+					if (content === "") {
+						return `Error: file not found: ${path}`;
+					}
+					const archivedPath = `${path}.archived`;
+					await overwrite(backend, archivedPath, content);
+					return `Archived ${path} → ${archivedPath}.`;
+				}
+
+				if (action === "mark_permanent") {
+					const hasFile = await exists(backend, path);
+					if (!hasFile) {
+						return `Error: file not found: ${path}`;
+					}
+					const markerPath = `${path}.permanent`;
+					await overwrite(backend, markerPath, "");
+					return `Marked ${path} permanent — lint will skip it.`;
+				}
+
+				return "Error: unknown action";
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				return `Error: ${message}`;
+			}
+		},
+		{
+			name: "memory_maintain",
+			description: MEMORY_MAINTAIN_PROMPT,
+			schema: z.object({
+				action: z
+					.enum(["touch", "archive", "mark_permanent"])
+					.describe("Maintenance action to perform."),
+				path: z
+					.string()
+					.describe("Full path of the file to maintain (e.g. /memory/notes/my-note.md)."),
 			}),
 		},
 	);


### PR DESCRIPTION
## Summary

Fixes 6 issues found during code review of the memory subsystem:

### Session loader (session_loader.ts)
- **Output respects cap**:  now reserves suffix budget () before accumulating lines — output no longer exceeds 
- **Test passes**: suffix now includes word "truncated" and actionable guidance (grep + memory_lint + rotate_actuel)

### Runtime context (runtime_context.ts)
- ****: Default raised from 2 → 4 user turns in checkpointed conversations. Better multi-turn context for complex tasks.

### Lint (lint.ts)
- **overBudget includes USER_PROFILE_PATH**: Char measurement now covers all three files in the snapshot block (previously missed user profile overhead)
- **Markers filtered from orphan/empty-slug**:  and  marker files are now excluded from orphan file detection and empty-slug-path checks

### Memory tools (memory_tools.ts + factory.ts)
- **Lock key fixed**:  lock reverted to  only. The composite  key allowed concurrent writes to different notes to corrupt the shared index
- **memory_maintain registered**:  added to factory.ts toolset — the tool was dead code before
- **Path validation**:  path schema now validates to , , or  roots
- **Archive removes original**:  action now calls  after writing the archive copy — previously left a stale orphan on disk
- **exists() check**: All three actions now use  rather than empty-string read to detect missing files

## Test results
```
  21 pass, 0 fail
  41 expect() calls
```

## Breaking changes
None — all changes are bug fixes or additive.

Closes #4