### PR TITLE
docs: Codex pull-agent smoke

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -38,6 +38,7 @@ Legacy task lists in this directory still exist and remain valid. New execution-
 | [CSV and Excel Spreadsheets](feature-csv-excel.md) | [RALPHEX plan](../plans/csv-excel.md) |
 | [Scheduled Timers](feature-scheduled-timers.md) | [RALPHEX plan](../plans/scheduled-timers.md) |
 | [Tool Activity Status Messages](feature-tool-activity-status.md) | [RALPHEX plan](../plans/tool-activity-status.md) |
+| [Codex Pull-Agent Smoke](codex-pull-agent-smoke.md) | [RALPHEX plan](../plans/7-docs--Codex-pull-agent-smoke.md) |
 
 ---
 

--- a/docs/features/codex-pull-agent-smoke.md
+++ b/docs/features/codex-pull-agent-smoke.md
@@ -1,0 +1,6 @@
+# Codex Pull-Agent Smoke
+
+This documentation file was created by the pull-agent smoke test.
+
+The smoke goal is to verify that the GoodKiddo pull-agent can run RALPHEX with
+Codex coding at medium effort and reviewing at high effort.

--- a/docs/plans/7-docs--Codex-pull-agent-smoke.md
+++ b/docs/plans/7-docs--Codex-pull-agent-smoke.md
@@ -1,0 +1,18 @@
+# Plan: Codex pull-agent smoke doc
+
+## Overview
+Add a tiny documentation-only smoke artifact proving the GoodKiddo pull-agent can run ralphex with Codex as coder and reviewer.
+
+## Constraints
+- Documentation-only change.
+- Do not modify runtime code, package files, lockfiles, or CI config.
+- Keep the change small and easy to review.
+
+## Validation Commands
+- `bun --version`
+
+### Task 1: Add smoke documentation
+- [x] Create `docs/features/codex-pull-agent-smoke.md`.
+- [x] Document that this file was created by the pull-agent smoke test.
+- [x] Include the agent goal: Codex coding at medium effort and review at high effort.
+- [x] Keep the document under 40 lines.


### PR DESCRIPTION
## Summary
- Implements GitHub issue #7 via ralphex pull-agent agent-1.
- Source plan: docs/plans/7-docs--Codex-pull-agent-smoke.md.

## Validation
- ralphex exit code: 0
- ralphex log: /home/klonclaw/.ralphex/logs/agent-1_ralphex_20260430_091107.log

Closes #7
