### PR TITLE
[codex] fix landing PostHog production init

### DIFF
--- a/landing/package.json
+++ b/landing/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "scripts": {
-    "build": "bun build ./index.html --outdir ./dist --production"
+    "build": "bun build ./index.html --outdir ./dist --production --env=POSTHOG_*"
   },
   "dependencies": {
     "posthog-js": "^1",

--- a/landing/src/main.jsx
+++ b/landing/src/main.jsx
@@ -2,11 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import posthog from 'posthog-js';
 
-const env = typeof process !== 'undefined' ? process.env : {};
+const posthogKey = process.env.POSTHOG_KEY || '';
+const posthogHost = process.env.POSTHOG_HOST || 'https://us.i.posthog.com';
 
-if (env.POSTHOG_KEY) {
-  posthog.init(env.POSTHOG_KEY, {
-    api_host: env.POSTHOG_HOST,
+if (posthogKey) {
+  posthog.init(posthogKey, {
+    api_host: posthogHost,
     defaults: '2026-01-30',
   });
 }

--- a/ops/README.md
+++ b/ops/README.md
@@ -132,6 +132,9 @@ Vault file and installs `uvx` so the runtime can launch
   through systemd instead of a one-off `docker-compose up -d` task.
 - nginx serves the generated `landing/dist/` bundle for `bot_main_domain` over
   origin HTTP and proxies the Bun file-share UI for `bot_app_domain`.
+- Landing analytics are embedded at build time. Set `landing_posthog_key` and
+  `landing_posthog_host` before provisioning so `bun run build` can inline the
+  browser PostHog config into `landing/dist`.
 - The embedded bot browser UI is built from the root workspace with
   `bun run web:build`; the bot service reads the generated `web/dist` files.
 - The bot gets `SEARXNG_API_BASE` and `AGENT_BROWSER_EXECUTABLE_PATH` through

--- a/ops/ansible/examples/goodkiddo_prod.10-env.yml.example
+++ b/ops/ansible/examples/goodkiddo_prod.10-env.yml.example
@@ -5,6 +5,11 @@
 bot_main_domain: example.com
 bot_app_domain: "app.{{ bot_main_domain }}"
 
+# Browser-side PostHog project key for the public landing page.
+# This key is embedded into landing/dist at build time and is not a secret.
+landing_posthog_key: ""
+landing_posthog_host: https://us.i.posthog.com
+
 # Set this when Ansible should clone/update the repository on the host.
 # Leave empty when you place the checkout on the host yourself.
 bot_repo_url: ""

--- a/ops/ansible/group_vars/goodkiddo_prod/00-safe-defaults.yml
+++ b/ops/ansible/group_vars/goodkiddo_prod/00-safe-defaults.yml
@@ -42,6 +42,8 @@ bot_postgres_user: goodkiddo
 bot_database_url: ""
 
 bot_app_domain: ""
+landing_posthog_key: ""
+landing_posthog_host: https://us.i.posthog.com
 
 telegram_allowed_chat_id: ""
 blocked_user_message: Access not configured. Contact the admin.

--- a/ops/ansible/tasks/app.yml
+++ b/ops/ansible/tasks/app.yml
@@ -76,6 +76,8 @@
   environment:
     HOME: "{{ bot_home }}"
     PATH: "/usr/local/bin:/usr/bin:/bin"
+    POSTHOG_KEY: "{{ landing_posthog_key | default('') }}"
+    POSTHOG_HOST: "{{ landing_posthog_host | default('https://us.i.posthog.com') }}"
   become_user: "{{ bot_user }}"
   notify: restart bot service
 


### PR DESCRIPTION
## Summary

Fixes the public landing build so PostHog initializes in production browsers instead of depending on a runtime `process.env` lookup.

## What changed

- Inline `POSTHOG_*` variables during the Bun landing build.
- Read `process.env.POSTHOG_KEY` / `POSTHOG_HOST` directly so Bun can replace them at build time.
- Pass landing PostHog settings through the production Ansible build task.
- Document the production analytics configuration in the ops README and example vars.

## Root cause

The production bundle kept `typeof process !== 'undefined' ? process.env : {}` in the browser. Normal browsers do not provide the production `POSTHOG_KEY`, so `posthog.init()` never ran.

## Validation

- `bun run landing:build`
- `git diff --check`
- Verified the active built JS has no `process.env` / `POSTHOG_KEY` runtime guard and contains the inlined PostHog key when built with local landing env config.
