### PR TITLE
[codex] Fix file-share nginx proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ in [`ops/ansible/`](./ops/ansible/).
 
 That playbook installs Bun, provisions a local PostgreSQL database
 and role, builds the landing and embedded bot web UI as static files, serves
-the generated `landing/dist/` bundle through nginx as the public
-origin behind Cloudflare Flexible SSL for the main and `app.` hostnames,
-installs the local browser/search stack (`google-chrome-stable`,
+the generated `landing/dist/` bundle through nginx for the main hostname,
+serves the `app.` file-share UI bundle through nginx behind Cloudflare Flexible
+SSL, proxies file-share API and download routes to the Bun service, installs
+the local browser/search stack (`google-chrome-stable`,
 `agent-browser`, SearXNG), and runs the bot as a systemd service bound to
 localhost HTTP. It is now structured around separate inventory, non-secret
 vars, and Vault-backed secret vars so you do not need to edit production values

--- a/ops/README.md
+++ b/ops/README.md
@@ -16,7 +16,7 @@ The playbook provisions:
 - an HTTP-only nginx origin intended to sit behind Cloudflare Flexible SSL
 - the generated `landing/dist/` bundle served by nginx after running the
   landing `bun build` script
-- the `web/` bot UI bundle consumed by the bot service after running `bun run web:build`
+- the `web/` bot UI bundle served by nginx after running `bun run web:build`
 - a managed environment file at `/etc/goodkiddo/bot.env`
 - a systemd service that runs `bun src/bin/bot.ts` from `bot/`
 - optional Telegram image understanding through MiniMax MCP when
@@ -130,8 +130,10 @@ Vault file and installs `uvx` so the runtime can launch
   `bot_searxng_host:bot_searxng_port`.
 - The SearXNG compose stack is managed by `{{ bot_searxng_service_name }}`
   through systemd instead of a one-off `docker-compose up -d` task.
-- nginx serves the generated `landing/dist/` bundle for `bot_main_domain` over
-  origin HTTP and proxies the Bun file-share UI for `bot_app_domain`.
+- nginx serves the generated `landing/dist/` bundle for `bot_main_domain` and
+  the generated `web/dist` file-share UI under `/fs` for `bot_app_domain`.
+- `/api/fs/...` and `/_dl` are proxied to the Bun web server for authenticated
+  boot, browse, preview, and download operations.
 - Landing analytics are embedded at build time. Set `landing_posthog_key` and
   `landing_posthog_host` before provisioning so `bun run build` can inline the
   browser PostHog config into `landing/dist`.

--- a/ops/ansible/templates/nginx-goodkiddo-http.conf.j2
+++ b/ops/ansible/templates/nginx-goodkiddo-http.conf.j2
@@ -20,8 +20,12 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    location = /fs {
+        return 308 /fs/$is_args$args;
+    }
+
     location /fs/ {
-        root {{ bot_web_dist_dir }};
+        alias {{ bot_web_dist_dir }}/;
         try_files $uri $uri/ /fs/index.html;
     }
 


### PR DESCRIPTION
## Summary

- Serve `/fs` from nginx static files using `alias` so `/fs/index.html` maps to `web/dist/index.html`.
- Preserve query parameters when redirecting slashless `/fs` to `/fs/`.
- Keep `/api/fs/...` and `/_dl` proxied to the Bun web server for authenticated boot, browse, preview, and download operations.
- Update production docs to describe the static UI plus proxied API split.

## Root Cause

Production nginx used `root {{ bot_web_dist_dir }}` inside `location /fs/`. That maps `/fs/index.html` to `web/dist/fs/index.html`, but the web build emits `web/dist/index.html`. The bad SPA fallback path can produce nginx internal redirect failure and the generic `500 Internal Server Error` page before the React UI boots.

## Validation

- `bun test bot/src/server/routes.test.ts`
- `git diff --check`
