### PR TITLE
docs: add GoodKiddo Fetch Card micro-slice plan

### DIFF
--- a/docs/plans/goodkiddo-slice-2a-fetch-card-renderer.md
+++ b/docs/plans/goodkiddo-slice-2a-fetch-card-renderer.md
@@ -1,0 +1,72 @@
+# Plan: GoodKiddo Slice 2a — Fetch Card Renderer
+
+> Parent roadmap: [`goodkiddo-v0-product-piece-slices.md`](./goodkiddo-v0-product-piece-slices.md)
+>
+> Feature scope: [`docs/features/goodkiddo-fetch-v0.md`](../features/goodkiddo-fetch-v0.md)
+
+## Goal
+
+Add one tiny, deterministic building block: a Fetch Card formatter.
+
+This does **not** add `/fetch`, group routing, recent-chat context, scheduler, profile setup, or any new agent behavior. It only gives future Fetch work one compact Telegram-native output shape.
+
+## User-visible shape
+
+```text
+🐶 Fetched
+Noticed: [one concrete unfinished-business signal]
+Prepared: [artifact type + short summary]
+Missing: [one blocker only, or none]
+Source: [direct ask / recent chat / forwarded case / public source]
+
+[artifact body]
+```
+
+## Product rules
+
+- Keep it compact enough for Telegram.
+- `Noticed` must be concrete, not generic.
+- `Prepared` must name the artifact type: draft, checklist, missing question, short research note, incident summary, or next-step card.
+- `Missing` is either `none` or one blocker.
+- No approval-flow language.
+- No dangerous-action language: GoodKiddo prepares text only.
+
+## Likely files
+
+Verify exact paths before implementing.
+
+- Create: `bot/src/capabilities/fetch/fetch_card.ts`
+- Create: `bot/src/capabilities/fetch/fetch_card.test.ts`
+
+## Task 1: Add Fetch Card formatter
+
+- [ ] Create `FetchCardInput` with fields: `noticed`, `prepared`, `missing`, `source`, `body`.
+- [ ] Create `formatFetchCard(input)`.
+- [ ] Output starts with `🐶 Fetched`.
+- [ ] Render labels exactly: `Noticed:`, `Prepared:`, `Missing:`, `Source:`.
+- [ ] Render `Missing: none` when no blocker exists.
+- [ ] Keep output plain Telegram-friendly Markdown; no tables.
+
+Done when a deterministic Fetch Card can be formatted without calling the agent.
+
+## Task 2: Test the formatter
+
+- [ ] Test normal card formatting.
+- [ ] Test `Missing: none` formatting.
+- [ ] Test multiline body formatting.
+- [ ] Test formatter does not add approval/action wording by itself.
+
+Run:
+
+```bash
+cd bot && bun test src/capabilities/fetch/fetch_card.test.ts
+cd bot && bun run typecheck
+```
+
+## Acceptance checklist
+
+- [ ] No Telegram command behavior changes.
+- [ ] No group/recent-context behavior changes.
+- [ ] No scheduler, Morning Fetch, profile wizard, dashboard, or loop forms.
+- [ ] Formatter output matches the Fetch Card shape.
+- [ ] Tests and typecheck pass.

--- a/docs/plans/goodkiddo-v0-product-piece-slices.md
+++ b/docs/plans/goodkiddo-v0-product-piece-slices.md
@@ -48,19 +48,32 @@ Build:
 
 Plan: [`goodkiddo-slice-1-quiet-group-watcher.md`](./goodkiddo-slice-1-quiet-group-watcher.md)
 
-### Slice 2: Manual Fetch surfaces
+### Slice 2a: Fetch Card renderer
 
-Product pieces: Fetch, smart out of the box, useful before asking, small artifact.
+Product pieces: Fetch, small artifact, no dangerous hands.
 
-Goal: make the doggo’s existing intelligence easy to call before scheduler/profile work.
+Goal: create one deterministic Fetch Card output shape before adding new Telegram behavior.
 
 Build:
 
-- `/fetch` command;
-- mention/reply-based Fetch in groups;
-- forwarded-case/direct-ask handling using recent context where available;
-- Fetch Card renderer with compact output contract;
-- one blocker question max when critical info is missing.
+- `formatFetchCard` helper;
+- tests for normal card, `Missing: none`, multiline body, and no approval/action wording;
+- no `/fetch` command, group routing, recent-context lookup, scheduler, profile, dashboard, or loop forms.
+
+Plan: [`goodkiddo-slice-2a-fetch-card-renderer.md`](./goodkiddo-slice-2a-fetch-card-renderer.md)
+
+### Slice 2b: Manual `/fetch` command
+
+Product pieces: Fetch, smart out of the box, useful before asking, Telegram-native.
+
+Goal: make the formatter callable from a tiny manual surface.
+
+Build later:
+
+- `/fetch` with direct text in DM;
+- one Fetch Card through the existing agent flow;
+- one blocker question max when critical info is missing;
+- no group/recent-context behavior until a later slice.
 
 ### Slice 3: Better business nose
 


### PR DESCRIPTION
## Summary
- Replace the too-large Manual Fetch surfaces plan with a tiny Slice 2a plan: Fetch Card renderer only.
- Link the roadmap to the smaller `goodkiddo-slice-2a-fetch-card-renderer.md` plan.
- Push `/fetch`, group routing, forwarded cases, recent-context lookup, scheduler, profile, dashboard, and loop forms to later slices.

## Validation
- git diff --check
