### PR TITLE
feat: add GoodKiddo Fetch Card formatter

### DIFF
--- a/bot/src/capabilities/fetch/fetch_card.test.ts
+++ b/bot/src/capabilities/fetch/fetch_card.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { formatFetchCard } from "./fetch_card";
+
+describe("formatFetchCard", () => {
+	test("formats a normal fetch card", () => {
+		expect(
+			formatFetchCard({
+				noticed: "Design review is waiting on the mobile layout decision.",
+				prepared: "summary with the remaining layout choices",
+				missing: "mobile breakpoint preference",
+				source: "direct ask",
+				body: "Option A keeps the checkout compact.\nOption B gives the promo field more room.",
+			}),
+		).toBe(`🐶 Fetched
+Noticed: Design review is waiting on the mobile layout decision.
+Prepared: summary with the remaining layout choices
+Missing: mobile breakpoint preference
+Source: direct ask
+
+Option A keeps the checkout compact.
+Option B gives the promo field more room.`);
+	});
+
+	test("renders Missing: none when missing is absent, null, or blank", () => {
+		const baseInput = {
+			noticed: "The rollout note still needs a final owner.",
+			prepared: "brief status card",
+			source: "recent chat",
+			body: "The release is otherwise ready.",
+		};
+		const expected = `🐶 Fetched
+Noticed: The rollout note still needs a final owner.
+Prepared: brief status card
+Missing: none
+Source: recent chat
+
+The release is otherwise ready.`;
+
+		expect(formatFetchCard(baseInput)).toBe(expected);
+		expect(formatFetchCard({ ...baseInput, missing: null })).toBe(expected);
+		expect(formatFetchCard({ ...baseInput, missing: "   " })).toBe(expected);
+	});
+
+	test("preserves multiline body after one blank line following source", () => {
+		const output = formatFetchCard({
+			noticed: "Invoice reconciliation is unfinished.",
+			prepared: "checklist with next steps",
+			missing: "",
+			source: "forwarded case",
+			body: "1. Match Stripe payout.\n\n2. Confirm tax category.\n3. Send note.",
+		});
+
+		expect(output).toBe(`🐶 Fetched
+Noticed: Invoice reconciliation is unfinished.
+Prepared: checklist with next steps
+Missing: none
+Source: forwarded case
+
+1. Match Stripe payout.
+
+2. Confirm tax category.
+3. Send note.`);
+	});
+
+	test("does not add approval-flow or dangerous-action wording", () => {
+		const output = formatFetchCard({
+			noticed: "The backup audit has an open follow-up.",
+			prepared: "short audit note",
+			source: "public source",
+			body: "Backups completed at 03:00 UTC.",
+		});
+
+		expect(output.toLowerCase()).not.toContain("approval");
+		expect(output.toLowerCase()).not.toContain("approve");
+		expect(output.toLowerCase()).not.toContain("dangerous");
+		expect(output.toLowerCase()).not.toContain("action required");
+	});
+});

--- a/bot/src/capabilities/fetch/fetch_card.ts
+++ b/bot/src/capabilities/fetch/fetch_card.ts
@@ -1,0 +1,21 @@
+export type FetchCardInput = {
+	noticed: string;
+	prepared: string;
+	missing?: string | null;
+	source: string;
+	body: string;
+};
+
+export function formatFetchCard(input: FetchCardInput): string {
+	const missing = input.missing?.trim() || "none";
+
+	return [
+		"🐶 Fetched",
+		`Noticed: ${input.noticed}`,
+		`Prepared: ${input.prepared}`,
+		`Missing: ${missing}`,
+		`Source: ${input.source}`,
+		"",
+		input.body,
+	].join("\n");
+}


### PR DESCRIPTION
## Summary
- Add deterministic `formatFetchCard` helper for the GoodKiddo Fetch Card contract.
- Cover normal card output, `Missing: none`, multiline bodies, and no approval/action wording added by the formatter.
- Keep scope to the tiny Slice 2a building block: no `/fetch`, no Telegram routing, no recent context, no forwarded-case handling.

## Validation
- `bun test bot/src/capabilities/fetch/fetch_card.test.ts` ✅
- `bunx --bun biome check bot/src/capabilities/fetch/fetch_card.ts bot/src/capabilities/fetch/fetch_card.test.ts` ✅
- `bun run typecheck` ⚠️ fails on pre-existing unrelated errors in spreadsheet/tabular/channel tests; no errors reported in changed Fetch Card files.
