### PR TITLE
feat(ops): add production self-autoprovisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ vars, and Vault-backed secret vars so you do not need to edit production values
 inside the playbook. It intentionally leaves Firecracker and execution sandbox
 setup out for now; the example production vars keep `ENABLE_EXECUTE=false`.
 
-Start with [`ops/README.md`](./ops/README.md).
+Start with [`ops/README.md`](./ops/README.md). It also documents optional
+self-autoprovisioning: production can poll the repository every 15 minutes with
+a read-only deploy key and run the playbook locally when `main` changes.
 
 For release checks, run:
 

--- a/ops/README.md
+++ b/ops/README.md
@@ -39,7 +39,11 @@ forwards requests to the origin over HTTP.
 - [`ansible/examples/goodkiddo_prod.20-secrets.vault.yml.example`](./ansible/examples/goodkiddo_prod.20-secrets.vault.yml.example) - starter secret vars
 - [`ansible/templates/searxng.env.j2`](./ansible/templates/searxng.env.j2) - local SearXNG runtime env
 - [`ansible/templates/goodkiddo-searxng.service.j2`](./ansible/templates/goodkiddo-searxng.service.j2) - systemd unit for the SearXNG stack
-- `ansible/tasks/` - split task files for preflight, packages, app, search stack, PostgreSQL, bot service, and nginx
+- [`ansible/tasks/autoprovision_key.yml`](./ansible/tasks/autoprovision_key.yml) - readonly deploy key and Git host setup
+- [`ansible/tasks/autoprovision.yml`](./ansible/tasks/autoprovision.yml) - optional production self-autoprovisioning from a readonly deploy key
+- [`ansible/templates/goodkiddo-autoprovision.sh.j2`](./ansible/templates/goodkiddo-autoprovision.sh.j2) - update detector + local Ansible runner
+- [`ansible/templates/goodkiddo-autoprovision.service.j2`](./ansible/templates/goodkiddo-autoprovision.service.j2) and [`ansible/templates/goodkiddo-autoprovision.timer.j2`](./ansible/templates/goodkiddo-autoprovision.timer.j2) - systemd service/timer pair
+- `ansible/tasks/` - split task files for preflight, packages, app, search stack, PostgreSQL, bot service, nginx, and self-autoprovisioning
 
 ## Safer Layout
 
@@ -105,7 +109,75 @@ Vault file and installs `uvx` so the runtime can launch
    ansible-playbook -i ops/ansible/inventory/production.ini ops/ansible/production.yml --ask-vault-pass
    ```
 
-8. After the service is up, provision Telegram chats with the existing admin CLI:
+8. Optional: enable self-autoprovisioning after the first successful manual run.
+
+   Create a GitHub deploy key with **read-only** access to this repository. Put
+   the private key either in the encrypted Vault var
+   `bot_autoprovision_deploy_key_private` or manually on the host at
+   `bot_autoprovision_deploy_key_path` with `0600 root:root` permissions. The
+   timer uses a separate root-owned control checkout (`bot_autoprovision_repo_dir`)
+   to run Ansible; keep it different from `bot_app_dir` so a compromised bot
+   process cannot mutate root-run playbooks/templates.
+
+   Copy the real production vars to a root-owned location outside the app and
+   control checkouts. The timer passes these files to `ansible-playbook` as
+   explicit extra-vars; if any configured file is missing, unreadable, not
+   root-owned, or group/world-writable, the timer skips that tick without
+   recording the repo SHA as deployed.
+
+   In `ops/ansible/group_vars/goodkiddo_prod/10-env.yml`:
+
+   ```yaml
+   bot_repo_url: git@github.com:KlonD90/goodkiddo.git
+   bot_repo_version: main
+   bot_autoprovision_enabled: true
+   bot_autoprovision_interval: 15min
+   bot_autoprovision_vars_dir: /etc/goodkiddo/ansible-vars
+   bot_autoprovision_extra_vars_files:
+     - "{{ bot_autoprovision_vars_dir }}/10-env.yml"
+     - "{{ bot_autoprovision_vars_dir }}/20-secrets.vault.yml"
+   bot_autoprovision_repo_dir: /opt/goodkiddo/autoprovision-repo
+   bot_autoprovision_state_file: /var/lib/goodkiddo/autoprovision-last-successful-sha
+   bot_autoprovision_deploy_key_path: /etc/goodkiddo/deploy_readonly_key
+   bot_autoprovision_known_hosts_file: /etc/goodkiddo/autoprovision_known_hosts
+   bot_autoprovision_vault_password_file: /etc/goodkiddo/ansible-vault-pass
+   ```
+
+   `bot_autoprovision_known_hosts` defaults to GitHub's published SSH host keys,
+   written to the dedicated `bot_autoprovision_known_hosts_file` used by the
+   deploy-key Git commands. Override it only with operator-verified keys for a
+   different Git host; do not bootstrap production trust from unaudited
+   `ssh-keyscan` output.
+
+   If production vars remain Vault-encrypted, create the vault password file on
+   the server as root-only:
+
+   ```bash
+   sudo install -m 0600 -o root -g root /dev/null /etc/goodkiddo/ansible-vault-pass
+   sudo editor /etc/goodkiddo/ansible-vault-pass
+   ```
+
+   Then run the playbook once manually again. It installs
+   `goodkiddo-autoprovision.timer`. Every 15 minutes the host checks that the
+   root-owned vars/secrets files listed in `bot_autoprovision_extra_vars_files`
+   are readable and root-controlled. If any are missing or insecure, that timer
+   tick logs the path and skips deployment without recording success. When vars
+   are present, it checks the readonly deploy key against `bot_repo_version`;
+   when the SHA changed, it updates the root-owned control checkout, runs the
+   production playbook locally through a localhost inventory with those extra
+   vars, and records the SHA only after Ansible succeeds so failed or skipped
+   runs retry on the next timer tick.
+
+   Useful production checks:
+
+   ```bash
+   sudo systemctl list-timers goodkiddo-autoprovision.timer
+   sudo systemctl status goodkiddo-autoprovision.timer
+   sudo journalctl -u goodkiddo-autoprovision.service -n 100 --no-pager
+   sudo systemctl start goodkiddo-autoprovision.service
+   ```
+
+9. After the service is up, provision Telegram chats with the existing admin CLI:
 
    ```bash
    sudo systemd-run --wait --pipe \

--- a/ops/ansible/examples/goodkiddo_prod.10-env.yml.example
+++ b/ops/ansible/examples/goodkiddo_prod.10-env.yml.example
@@ -16,6 +16,30 @@ bot_repo_url: ""
 bot_repo_version: main
 bot_repo_update: false
 
+# Optional: let production poll the readonly deploy key every 15 minutes and
+# run this Ansible playbook against itself when bot_repo_version changes.
+bot_autoprovision_enabled: false
+bot_autoprovision_interval: 15min
+# The timer skips a deployment tick without recording success if any configured
+# vars/secrets file below is missing or unreadable on the host, or if a file is
+# not root-owned / is group- or world-writable.
+bot_autoprovision_vars_dir: /etc/goodkiddo/ansible-vars
+bot_autoprovision_extra_vars_files:
+  - "{{ bot_autoprovision_vars_dir }}/10-env.yml"
+  - "{{ bot_autoprovision_vars_dir }}/20-secrets.vault.yml"
+# Separate root-owned control checkout used only to run Ansible. Keep it
+# different from bot_app_dir so the bot service cannot mutate root-run playbooks.
+bot_autoprovision_repo_dir: /opt/goodkiddo/autoprovision-repo
+bot_autoprovision_state_file: /var/lib/goodkiddo/autoprovision-last-successful-sha
+bot_autoprovision_deploy_key_path: /etc/goodkiddo/deploy_readonly_key
+bot_autoprovision_known_hosts_file: /etc/goodkiddo/autoprovision_known_hosts
+# Defaults pin GitHub's published SSH host keys. Override this for another host;
+# do not replace it with unaudited ssh-keyscan output.
+# bot_autoprovision_known_hosts:
+#   - github.com ssh-ed25519 ...
+# If the Vault vars stay encrypted, create this root-only file on the server.
+bot_autoprovision_vault_password_file: /etc/goodkiddo/ansible-vault-pass
+
 bot_manage_postgres: true
 bot_postgres_db: goodkiddo
 bot_postgres_user: goodkiddo

--- a/ops/ansible/examples/goodkiddo_prod.20-secrets.vault.yml.example
+++ b/ops/ansible/examples/goodkiddo_prod.20-secrets.vault.yml.example
@@ -8,3 +8,6 @@ transcription_api_key: ""
 minimax_api_key: ""
 telegram_bot_token: change-me
 bot_searxng_secret: change-me-long-random-string
+# Optional. Store the private half of a GitHub readonly deploy key here, or
+# leave empty and place it manually at bot_autoprovision_deploy_key_path.
+bot_autoprovision_deploy_key_private: ""

--- a/ops/ansible/group_vars/goodkiddo_prod/00-safe-defaults.yml
+++ b/ops/ansible/group_vars/goodkiddo_prod/00-safe-defaults.yml
@@ -28,6 +28,30 @@ bot_repo_url: ""
 bot_repo_version: main
 bot_repo_update: false
 
+bot_autoprovision_enabled: false
+bot_autoprovision_interval: 15min
+bot_autoprovision_on_boot_sec: 5min
+bot_autoprovision_randomized_delay_sec: 60s
+bot_autoprovision_service_name: goodkiddo-autoprovision
+bot_autoprovision_script_path: /usr/local/sbin/goodkiddo-autoprovision
+bot_autoprovision_inventory_file: "{{ bot_env_dir }}/autoprovision.inventory"
+bot_autoprovision_known_hosts_file: "{{ bot_env_dir }}/autoprovision_known_hosts"
+bot_autoprovision_vars_dir: "{{ bot_env_dir }}/ansible-vars"
+bot_autoprovision_extra_vars_files:
+  - "{{ bot_autoprovision_vars_dir }}/10-env.yml"
+  - "{{ bot_autoprovision_vars_dir }}/20-secrets.vault.yml"
+bot_autoprovision_repo_dir: /opt/goodkiddo/autoprovision-repo
+bot_autoprovision_state_file: /var/lib/goodkiddo/autoprovision-last-successful-sha
+bot_autoprovision_deploy_key_path: "{{ bot_env_dir }}/deploy_readonly_key"
+bot_autoprovision_deploy_key_private: ""
+bot_autoprovision_vault_password_file: ""
+bot_autoprovision_lock_file: /run/goodkiddo-autoprovision.lock
+bot_autoprovision_git_host: github.com
+bot_autoprovision_known_hosts:
+  - github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+  - github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+  - github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
+
 bun_version: 1.3.11
 bun_install_dir: /opt/bun
 bun_download_base: "https://github.com/oven-sh/bun/releases/download/bun-v{{ bun_version }}"

--- a/ops/ansible/production.yml
+++ b/ops/ansible/production.yml
@@ -10,6 +10,9 @@
     - name: Install packages and runtimes
       ansible.builtin.include_tasks: tasks/packages.yml
 
+    - name: Prepare self-autoprovision deploy key
+      ansible.builtin.include_tasks: tasks/autoprovision_key.yml
+
     - name: Prepare application checkout and landing
       ansible.builtin.include_tasks: tasks/app.yml
 
@@ -24,6 +27,9 @@
 
     - name: Configure nginx
       ansible.builtin.include_tasks: tasks/nginx.yml
+
+    - name: Configure production self-autoprovisioning
+      ansible.builtin.include_tasks: tasks/autoprovision.yml
 
   handlers:
     - name: reload nginx

--- a/ops/ansible/tasks/app.yml
+++ b/ops/ansible/tasks/app.yml
@@ -13,6 +13,19 @@
     shell: /usr/sbin/nologin
     system: true
 
+- name: Validate self-autoprovision app/control checkout separation
+  ansible.builtin.assert:
+    that:
+      - (bot_autoprovision_repo_dir | default('') | trim) != ""
+      - (bot_autoprovision_repo_dir | string).startswith('/')
+      - bot_autoprovision_repo_dir != "/"
+      - bot_autoprovision_repo_dir != bot_app_dir
+      - not ((bot_autoprovision_repo_dir | string).startswith((bot_app_dir | string) ~ '/'))
+    fail_msg: >-
+      bot_autoprovision_repo_dir must be an absolute path outside bot_app_dir so
+      root-run playbooks and Git metadata cannot become bot-owned.
+  when: bot_autoprovision_enabled | bool
+
 - name: Ensure application directories exist
   ansible.builtin.file:
     path: "{{ item.path }}"
@@ -35,16 +48,151 @@
     recurse: true
     owner: "{{ bot_user }}"
     group: "{{ bot_group }}"
-  when: bot_repo_url | length > 0
+  when:
+    - bot_repo_url | length > 0
+    - not (bot_autoprovision_enabled | bool)
 
-- name: Optionally sync repository checkout
+- name: Optionally sync repository checkout as service user
   ansible.builtin.git:
     repo: "{{ bot_repo_url }}"
     dest: "{{ bot_app_dir }}"
     version: "{{ bot_repo_version }}"
     update: "{{ bot_repo_update }}"
   become_user: "{{ bot_user }}"
-  when: bot_repo_url | length > 0
+  when:
+    - bot_repo_url | length > 0
+    - not (bot_autoprovision_enabled | bool)
+  notify:
+    - restart bot service
+    - restart searxng stack
+
+- name: Ensure self-autoprovision control checkout parent exists
+  ansible.builtin.file:
+    path: "{{ bot_autoprovision_repo_dir | dirname }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when:
+    - bot_repo_url | length > 0
+    - bot_autoprovision_enabled | bool
+
+- name: Check existing self-autoprovision control checkout path
+  ansible.builtin.stat:
+    path: "{{ bot_autoprovision_repo_dir }}"
+  register: bot_autoprovision_control_dir_stat
+  when:
+    - bot_repo_url | length > 0
+    - bot_autoprovision_enabled | bool
+
+- name: Check existing self-autoprovision control checkout Git metadata
+  ansible.builtin.stat:
+    path: "{{ bot_autoprovision_repo_dir }}/.git"
+  register: bot_autoprovision_control_git_stat
+  when:
+    - bot_repo_url | length > 0
+    - bot_autoprovision_enabled | bool
+    - bot_autoprovision_control_dir_stat.stat.exists | default(false)
+
+- name: Look for unsafe entries in existing control checkout Git metadata
+  ansible.builtin.command:
+    argv:
+      - find
+      - "{{ bot_autoprovision_repo_dir }}/.git"
+      - "("
+      - "!"
+      - -user
+      - "0"
+      - -o
+      - -perm
+      - /022
+      - ")"
+      - -print
+      - -quit
+  register: bot_autoprovision_control_insecure_git_entries
+  changed_when: false
+  failed_when: false
+  when:
+    - bot_repo_url | length > 0
+    - bot_autoprovision_enabled | bool
+    - bot_autoprovision_control_git_stat.stat.isdir | default(false)
+
+- name: Remove unsafe existing self-autoprovision control checkout before Git sync
+  ansible.builtin.file:
+    path: "{{ bot_autoprovision_repo_dir }}"
+    state: absent
+  when:
+    - bot_repo_url | length > 0
+    - bot_autoprovision_enabled | bool
+    - bot_autoprovision_control_dir_stat.stat.exists | default(false)
+    - >-
+      (not (bot_autoprovision_control_dir_stat.stat.isdir | default(false)))
+      or ((bot_autoprovision_control_dir_stat.stat.uid | default(-1)) != 0)
+      or (bot_autoprovision_control_dir_stat.stat.wgrp | default(true))
+      or (bot_autoprovision_control_dir_stat.stat.woth | default(true))
+      or ((bot_autoprovision_control_git_stat.stat.exists | default(false)) and (
+        (not (bot_autoprovision_control_git_stat.stat.isdir | default(false)))
+        or ((bot_autoprovision_control_git_stat.stat.uid | default(-1)) != 0)
+        or (bot_autoprovision_control_git_stat.stat.wgrp | default(true))
+        or (bot_autoprovision_control_git_stat.stat.woth | default(true))
+      ))
+      or ((bot_autoprovision_control_insecure_git_entries.stdout | default('')) != '')
+
+- name: Sync root-owned control checkout with readonly deploy key
+  ansible.builtin.git:
+    repo: "{{ bot_repo_url }}"
+    dest: "{{ bot_autoprovision_repo_dir }}"
+    version: "{{ bot_repo_version }}"
+    update: true
+    key_file: "{{ bot_autoprovision_deploy_key_path }}"
+    accept_hostkey: false
+    ssh_opts: "-o BatchMode=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile={{ bot_autoprovision_known_hosts_file }} -o GlobalKnownHostsFile=/dev/null -o UpdateHostKeys=no"
+  when:
+    - bot_repo_url | length > 0
+    - bot_autoprovision_enabled | bool
+
+- name: Remove ignored and untracked files from root-owned control checkout
+  ansible.builtin.command:
+    argv:
+      - git
+      - -C
+      - "{{ bot_autoprovision_repo_dir }}"
+      - clean
+      - -ffdx
+  register: bot_autoprovision_control_clean
+  changed_when: bot_autoprovision_control_clean.stdout | length > 0
+  when:
+    - bot_repo_url | length > 0
+    - bot_autoprovision_enabled | bool
+
+- name: Ensure self-autoprovision control checkout is root-owned
+  ansible.builtin.file:
+    path: "{{ bot_autoprovision_repo_dir }}"
+    state: directory
+    recurse: true
+    owner: root
+    group: root
+  when:
+    - bot_repo_url | length > 0
+    - bot_autoprovision_enabled | bool
+
+- name: Sync application tree from root-owned control checkout
+  ansible.builtin.command:
+    argv:
+      - rsync
+      - -a
+      - --delete
+      - --itemize-changes
+      - --exclude
+      - .git
+      - "--chown={{ bot_user }}:{{ bot_group }}"
+      - "{{ bot_autoprovision_repo_dir }}/"
+      - "{{ bot_app_dir }}/"
+  register: bot_autoprovision_app_rsync
+  changed_when: bot_autoprovision_app_rsync.stdout | length > 0
+  when:
+    - bot_repo_url | length > 0
+    - bot_autoprovision_enabled | bool
   notify:
     - restart bot service
     - restart searxng stack

--- a/ops/ansible/tasks/autoprovision.yml
+++ b/ops/ansible/tasks/autoprovision.yml
@@ -1,0 +1,92 @@
+---
+- name: Stop self-autoprovision timer when disabled
+  ansible.builtin.systemd_service:
+    name: "{{ bot_autoprovision_service_name }}.timer"
+    enabled: false
+    state: stopped
+  failed_when: false
+  when: not (bot_autoprovision_enabled | bool)
+
+- name: Stop self-autoprovision service when disabled
+  ansible.builtin.systemd_service:
+    name: "{{ bot_autoprovision_service_name }}.service"
+    enabled: false
+    state: stopped
+  failed_when: false
+  when: not (bot_autoprovision_enabled | bool)
+
+- name: Validate self-autoprovision settings
+  ansible.builtin.assert:
+    that:
+      - (bot_repo_url | default('') | trim) != ""
+      - (bot_repo_version | default('') | trim) != ""
+      - (bot_autoprovision_interval | default('') | trim) != ""
+      - (bot_autoprovision_repo_dir | string).startswith('/')
+      - bot_autoprovision_repo_dir != "/"
+      - bot_autoprovision_repo_dir != bot_app_dir
+      - not ((bot_autoprovision_repo_dir | string).startswith((bot_app_dir | string) ~ '/'))
+      - bot_autoprovision_state_file != ""
+    fail_msg: >-
+      Self-autoprovisioning requires bot_repo_url, bot_repo_version, and
+      bot_autoprovision_interval. Use a read-only GitHub deploy key for bot_repo_url.
+  when: bot_autoprovision_enabled | bool
+
+- name: Re-check self-autoprovision deploy key material
+  ansible.builtin.include_tasks: tasks/autoprovision_key.yml
+  when: bot_autoprovision_enabled | bool
+
+- name: Install Ansible collections on the production host for future self-runs
+  ansible.builtin.command:
+    cmd: ansible-galaxy collection install -r "{{ bot_autoprovision_repo_dir }}/ops/ansible/requirements.yml"
+  register: bot_autoprovision_galaxy
+  changed_when: "'Installing' in bot_autoprovision_galaxy.stdout or 'Downloading' in bot_autoprovision_galaxy.stdout"
+  when: bot_autoprovision_enabled | bool
+
+- name: Render localhost inventory for self-autoprovisioning
+  ansible.builtin.template:
+    src: templates/goodkiddo-autoprovision.inventory.j2
+    dest: "{{ bot_autoprovision_inventory_file }}"
+    owner: root
+    group: root
+    mode: "0644"
+  when: bot_autoprovision_enabled | bool
+
+- name: Render self-autoprovision script
+  ansible.builtin.template:
+    src: templates/goodkiddo-autoprovision.sh.j2
+    dest: "{{ bot_autoprovision_script_path }}"
+    owner: root
+    group: root
+    mode: "0755"
+  when: bot_autoprovision_enabled | bool
+
+- name: Render self-autoprovision systemd service
+  ansible.builtin.template:
+    src: templates/goodkiddo-autoprovision.service.j2
+    dest: "/etc/systemd/system/{{ bot_autoprovision_service_name }}.service"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: reload systemd
+  when: bot_autoprovision_enabled | bool
+
+- name: Render self-autoprovision systemd timer
+  ansible.builtin.template:
+    src: templates/goodkiddo-autoprovision.timer.j2
+    dest: "/etc/systemd/system/{{ bot_autoprovision_service_name }}.timer"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: reload systemd
+  when: bot_autoprovision_enabled | bool
+
+- name: Flush systemd reload before enabling self-autoprovision timer
+  ansible.builtin.meta: flush_handlers
+  when: bot_autoprovision_enabled | bool
+
+- name: Enable and start self-autoprovision timer
+  ansible.builtin.systemd_service:
+    name: "{{ bot_autoprovision_service_name }}.timer"
+    enabled: true
+    state: started
+  when: bot_autoprovision_enabled | bool

--- a/ops/ansible/tasks/autoprovision_key.yml
+++ b/ops/ansible/tasks/autoprovision_key.yml
@@ -1,0 +1,67 @@
+---
+- name: Ensure autoprovision secret directory exists
+  ansible.builtin.file:
+    path: "{{ bot_env_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+  when: bot_autoprovision_enabled | bool
+
+- name: Ensure root SSH directory exists for readonly deploy key host checks
+  ansible.builtin.file:
+    path: /root/.ssh
+    state: directory
+    owner: root
+    group: root
+    mode: "0700"
+  when: bot_autoprovision_enabled | bool
+
+- name: Require pinned Git host SSH keys
+  ansible.builtin.assert:
+    that:
+      - bot_autoprovision_known_hosts is defined
+      - (bot_autoprovision_known_hosts | length) > 0
+    fail_msg: >-
+      Self-autoprovisioning requires pinned SSH known_hosts entries. Do not use
+      ssh-keyscan output blindly in production; set bot_autoprovision_known_hosts
+      to operator-verified host keys for {{ bot_autoprovision_git_host }}.
+  when: bot_autoprovision_enabled | bool
+
+- name: Install pinned Git host SSH keys for strict host checking
+  ansible.builtin.copy:
+    content: "{{ bot_autoprovision_known_hosts | join('\n') }}\n"
+    dest: "{{ bot_autoprovision_known_hosts_file }}"
+    owner: root
+    group: root
+    mode: "0600"
+  when: bot_autoprovision_enabled | bool
+
+- name: Render readonly deploy key from Vault when provided
+  ansible.builtin.copy:
+    content: "{{ bot_autoprovision_deploy_key_private | trim }}\n"
+    dest: "{{ bot_autoprovision_deploy_key_path }}"
+    owner: root
+    group: root
+    mode: "0600"
+  no_log: true
+  when:
+    - bot_autoprovision_enabled | bool
+    - (bot_autoprovision_deploy_key_private | default('') | trim) != ""
+
+- name: Check readonly deploy key exists
+  ansible.builtin.stat:
+    path: "{{ bot_autoprovision_deploy_key_path }}"
+  register: bot_autoprovision_deploy_key_stat
+  when: bot_autoprovision_enabled | bool
+
+- name: Fail when readonly deploy key is missing
+  ansible.builtin.assert:
+    that:
+      - bot_autoprovision_deploy_key_stat.stat.exists
+      - bot_autoprovision_deploy_key_stat.stat.readable
+    fail_msg: >-
+      Missing readable deploy key at {{ bot_autoprovision_deploy_key_path }}.
+      Add a GitHub read-only deploy key and store its private half in
+      bot_autoprovision_deploy_key_private or place it manually on the host.
+  when: bot_autoprovision_enabled | bool

--- a/ops/ansible/tasks/packages.yml
+++ b/ops/ansible/tasks/packages.yml
@@ -3,6 +3,7 @@
   ansible.builtin.apt:
     name:
       - acl
+      - ansible
       - ca-certificates
       - curl
       - gnupg
@@ -27,6 +28,8 @@
       - docker-compose
       - docker.io
       - nginx
+      - openssh-client
+      - rsync
       - unzip
     state: present
     update_cache: true

--- a/ops/ansible/templates/goodkiddo-autoprovision.inventory.j2
+++ b/ops/ansible/templates/goodkiddo-autoprovision.inventory.j2
@@ -1,0 +1,2 @@
+[goodkiddo_prod]
+localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3

--- a/ops/ansible/templates/goodkiddo-autoprovision.service.j2
+++ b/ops/ansible/templates/goodkiddo-autoprovision.service.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=GoodKiddo self-autoprovision from readonly deploy key
+Documentation=file://{{ bot_app_dir }}/ops/README.md
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart={{ bot_autoprovision_script_path }}
+Nice=5
+IOSchedulingClass=best-effort

--- a/ops/ansible/templates/goodkiddo-autoprovision.sh.j2
+++ b/ops/ansible/templates/goodkiddo-autoprovision.sh.j2
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+APP_DIR={{ bot_app_dir | quote }}
+CONTROL_DIR={{ bot_autoprovision_repo_dir | quote }}
+REPO_URL={{ bot_repo_url | quote }}
+REPO_VERSION={{ bot_repo_version | quote }}
+DEPLOY_KEY={{ bot_autoprovision_deploy_key_path | quote }}
+INVENTORY={{ bot_autoprovision_inventory_file | quote }}
+KNOWN_HOSTS_FILE={{ bot_autoprovision_known_hosts_file | quote }}
+LOCK_FILE={{ bot_autoprovision_lock_file | quote }}
+STATE_FILE={{ bot_autoprovision_state_file | quote }}
+VAULT_PASSWORD_FILE={{ bot_autoprovision_vault_password_file | quote }}
+EXTRA_VARS_FILES=(
+{% for vars_file in bot_autoprovision_extra_vars_files | default([]) %}
+  {{ vars_file | quote }}
+{% endfor %}
+)
+PLAYBOOK="${CONTROL_DIR}/ops/ansible/production.yml"
+REQUIREMENTS="${CONTROL_DIR}/ops/ansible/requirements.yml"
+
+log() {
+  printf '[%s] %s\n' "$(date -Is)" "$*"
+}
+
+fail() {
+  log "ERROR: $*" >&2
+  exit 1
+}
+
+root_owned_not_group_world_writable() {
+  local path="$1"
+  local owner_uid
+  local mode
+
+  [[ -e "${path}" ]] || return 1
+  owner_uid="$(stat -c '%u' "${path}" 2>/dev/null || printf 'unknown')"
+  mode="$(stat -c '%a' "${path}" 2>/dev/null || printf 'invalid')"
+  [[ "${owner_uid}" == "0" ]] || return 1
+  [[ "${mode}" =~ ^[0-7]+$ ]] || return 1
+  (( (8#${mode} & 0022) == 0 ))
+}
+
+root_only_secret_file() {
+  local path="$1"
+  local owner_uid
+  local mode
+
+  [[ -f "${path}" ]] || return 1
+  owner_uid="$(stat -c '%u' "${path}" 2>/dev/null || printf 'unknown')"
+  mode="$(stat -c '%a' "${path}" 2>/dev/null || printf 'invalid')"
+  [[ "${owner_uid}" == "0" ]] || return 1
+  [[ "${mode}" =~ ^[0-7]+$ ]] || return 1
+  (( (8#${mode} & 0077) == 0 ))
+}
+
+if [[ -z "${REPO_URL}" ]]; then
+  fail "bot_repo_url is empty; cannot self-autoprovision"
+fi
+
+if [[ -z "${REPO_VERSION}" ]]; then
+  fail "bot_repo_version is empty; cannot self-autoprovision"
+fi
+
+if [[ "${CONTROL_DIR}" == "${APP_DIR}" || "${CONTROL_DIR}" == "${APP_DIR}/"* ]]; then
+  fail "control checkout must be separate from and outside bot_app_dir"
+fi
+
+if [[ "${CONTROL_DIR}" != /* || "${CONTROL_DIR}" == "/" ]]; then
+  fail "control checkout must be an absolute non-root path"
+fi
+
+if [[ ! -r "${DEPLOY_KEY}" ]]; then
+  fail "readonly deploy key is missing or unreadable at ${DEPLOY_KEY}"
+fi
+
+if [[ ! -r "${KNOWN_HOSTS_FILE}" ]]; then
+  fail "pinned known_hosts file is missing or unreadable at ${KNOWN_HOSTS_FILE}"
+fi
+
+mkdir -p "$(dirname "${LOCK_FILE}")" "$(dirname "${STATE_FILE}")"
+exec 9>"${LOCK_FILE}"
+if ! flock -n 9; then
+  log "another autoprovision run is active; exiting"
+  exit 0
+fi
+
+export GIT_SSH_COMMAND="ssh -i ${DEPLOY_KEY} -o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=${KNOWN_HOSTS_FILE} -o GlobalKnownHostsFile=/dev/null -o UpdateHostKeys=no"
+
+missing_vars_count=0
+missing_vars_files=()
+insecure_vars_files=()
+for vars_file in "${EXTRA_VARS_FILES[@]}"; do
+  if [[ -z "${vars_file}" ]]; then
+    continue
+  fi
+  if [[ ! -r "${vars_file}" ]]; then
+    missing_vars_files+=("${vars_file}")
+    missing_vars_count=$((missing_vars_count + 1))
+    continue
+  fi
+
+  if ! root_owned_not_group_world_writable "${vars_file}"; then
+    insecure_vars_files+=("${vars_file}")
+  fi
+done
+
+if (( missing_vars_count > 0 )); then
+  log "production vars/secrets are missing or unreadable; skipping autoprovision this tick"
+  for vars_file in "${missing_vars_files[@]}"; do
+    log "missing vars file: ${vars_file}"
+  done
+  exit 0
+fi
+
+insecure_vars_count=0
+for vars_file in "${insecure_vars_files[@]}"; do
+  insecure_vars_count=$((insecure_vars_count + 1))
+done
+
+if (( insecure_vars_count > 0 )); then
+  log "production vars/secrets are not root-owned or are group/world-writable; skipping autoprovision this tick"
+  for vars_file in "${insecure_vars_files[@]}"; do
+    log "insecure vars file: ${vars_file}"
+  done
+  exit 0
+fi
+
+remote_query="refs/heads/${REPO_VERSION}"
+remote_sha="$(git ls-remote "${REPO_URL}" "${remote_query}" | awk 'NR == 1 { print $1 }')"
+if [[ -z "${remote_sha}" ]]; then
+  fail "could not resolve ${remote_query} from ${REPO_URL}"
+fi
+
+last_successful_sha=""
+if [[ -r "${STATE_FILE}" ]]; then
+  last_successful_sha="$(tr -d '[:space:]' < "${STATE_FILE}")"
+fi
+
+if [[ "${last_successful_sha}" == "${remote_sha}" ]]; then
+  log "repository already successfully provisioned at ${remote_sha}; nothing to do"
+  exit 0
+fi
+
+if [[ -e "${CONTROL_DIR}" && ! -d "${CONTROL_DIR}" ]]; then
+  fail "control checkout path exists but is not a directory: ${CONTROL_DIR}"
+fi
+
+if [[ -d "${CONTROL_DIR}" ]]; then
+  control_checkout_insecure=false
+  if ! root_owned_not_group_world_writable "${CONTROL_DIR}"; then
+    control_checkout_insecure=true
+  fi
+  if [[ -e "${CONTROL_DIR}/.git" ]]; then
+    if ! root_owned_not_group_world_writable "${CONTROL_DIR}/.git"; then
+      control_checkout_insecure=true
+    fi
+    insecure_git_entry="$(find "${CONTROL_DIR}/.git" \( ! -user 0 -o -perm /022 \) -print -quit 2>/dev/null || true)"
+    if [[ -n "${insecure_git_entry}" ]]; then
+      control_checkout_insecure=true
+    fi
+  fi
+  if [[ "${control_checkout_insecure}" == "true" ]]; then
+    log "control checkout is not root-controlled; replacing before running git"
+    rm -rf "${CONTROL_DIR}"
+  fi
+fi
+
+current_control_sha=""
+if [[ -d "${CONTROL_DIR}/.git" ]]; then
+  current_control_sha="$(git -C "${CONTROL_DIR}" rev-parse HEAD 2>/dev/null || true)"
+fi
+
+log "repository update detected: ${last_successful_sha:-never} -> ${remote_sha}"
+
+if [[ ! -d "${CONTROL_DIR}/.git" ]]; then
+  mkdir -p "$(dirname "${CONTROL_DIR}")"
+  rm -rf "${CONTROL_DIR}"
+  git clone --branch "${REPO_VERSION}" --single-branch "${REPO_URL}" "${CONTROL_DIR}"
+else
+  git -C "${CONTROL_DIR}" remote set-url origin "${REPO_URL}"
+  git -C "${CONTROL_DIR}" fetch --prune origin "${REPO_VERSION}"
+  git -C "${CONTROL_DIR}" reset --hard "${remote_sha}"
+  git -C "${CONTROL_DIR}" clean -ffdx
+fi
+
+chown -R root:root "${CONTROL_DIR}"
+
+if [[ -f "${REQUIREMENTS}" ]]; then
+  ansible-galaxy collection install -r "${REQUIREMENTS}"
+fi
+
+ansible_args=(
+  --inventory "${INVENTORY}"
+)
+
+if [[ -n "${VAULT_PASSWORD_FILE}" ]]; then
+  if [[ ! -r "${VAULT_PASSWORD_FILE}" ]]; then
+    log "vault password file is configured but unreadable at ${VAULT_PASSWORD_FILE}; skipping autoprovision this tick"
+    exit 0
+  fi
+  if ! root_only_secret_file "${VAULT_PASSWORD_FILE}"; then
+    log "vault password file is not a root-owned 0600-style file at ${VAULT_PASSWORD_FILE}; skipping autoprovision this tick"
+    exit 0
+  fi
+  ansible_args+=(--vault-password-file "${VAULT_PASSWORD_FILE}")
+fi
+
+for vars_file in "${EXTRA_VARS_FILES[@]}"; do
+  if [[ -z "${vars_file}" ]]; then
+    continue
+  fi
+  ansible_args+=(--extra-vars "@${vars_file}")
+done
+
+ansible_args+=("${PLAYBOOK}")
+
+log "running ansible-playbook against localhost inventory"
+ansible-playbook "${ansible_args[@]}"
+printf '%s\n' "${remote_sha}" > "${STATE_FILE}"
+chmod 0600 "${STATE_FILE}"
+log "autoprovision complete at ${remote_sha}"

--- a/ops/ansible/templates/goodkiddo-autoprovision.timer.j2
+++ b/ops/ansible/templates/goodkiddo-autoprovision.timer.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run GoodKiddo self-autoprovision every {{ bot_autoprovision_interval }}
+
+[Timer]
+OnBootSec={{ bot_autoprovision_on_boot_sec }}
+OnUnitActiveSec={{ bot_autoprovision_interval }}
+RandomizedDelaySec={{ bot_autoprovision_randomized_delay_sec }}
+Persistent=true
+Unit={{ bot_autoprovision_service_name }}.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- add optional production self-autoprovisioning via systemd service/timer polling every 15 minutes
- use a read-only deploy key, pinned dedicated SSH known_hosts, and a root-owned control checkout
- run local Ansible only after a repo SHA change, with last-successful SHA recorded only after Ansible succeeds
- load production vars/secrets from root-owned extra-vars files; skip the timer tick without recording success when required vars/secrets are missing or insecure

## Safety notes
- self-autoprovisioning is disabled by default
- app runtime tree is synced from the cleaned root-owned control checkout, not root Git in a bot-owned repo
- no private deploy key or secrets are committed; examples use placeholders

## Verification
- `git diff --check`
- YAML parse for `ops/ansible/**/*.yml`
- Jinja render of autoprovision templates
- `bash -n` on rendered autoprovision script
- static scan of staged added lines for obvious secrets/private keys: none
- `bun run test`
  - bot: 1095 pass / 0 fail
  - web: 6 pass / 0 fail
- independent reviewer: PASS, no HIGH/CRITICAL regressions found

## Not run
- `ansible-playbook --syntax-check`, `ansible-lint`, `shellcheck`: tools are not installed in this environment
