### PR TITLE
Optimize images and cache static assets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,6 @@
 
 ## Bun HTML asset notes
 
-- Social preview images in `landing/index.html` and `web/index.html` should point to the real checked-in local JPEG files, for example `./goodkiddo-og-image.jpeg`. Do not hardcode Bun-generated hashed filenames in source HTML.
-- Bun does not rewrite image paths inside `<meta property="og:image" ...>` or `<meta name="twitter:image" ...>` content attributes. To make Bun copy a social preview image into `dist/`, also reference the same local file through a supported HTML asset tag such as `<link rel="preload" as="image" href="./goodkiddo-og-image.jpeg" />`.
+- Social preview metadata in `landing/index.html` and `web/index.html` should use absolute public URLs, for example `https://whosagoodkiddo.me/goodkiddo-og-image.jpeg`. Do not hardcode Bun-generated hashed filenames in source HTML.
+- Bun does not rewrite image paths inside `<meta property="og:image" ...>`, `<meta property="og:logo" ...>`, or `<meta name="twitter:image" ...>` content attributes. To make Bun copy a social preview image into `dist/`, also reference the same local file through a supported HTML asset tag such as `<link rel="preload" as="image" href="./goodkiddo-og-image.jpeg" />`.
 - Keep the landing and web build scripts configured with `--asset-naming '[name].[ext]'` so the emitted social preview images keep the same filenames used by the meta tags. Verify with `bun run landing:build` or `bun run web:build` that the image is emitted into `dist/` under the real local filename.

--- a/landing/index.html
+++ b/landing/index.html
@@ -15,16 +15,19 @@
   <meta property="og:url" content="https://whosagoodkiddo.me/" />
   <meta property="og:title" content="GoodKiddo — Fetch one safe next move in Telegram" />
   <meta property="og:description" content="GoodKiddo is a friendly business dog in Telegram that watches messy chats, prepares one useful next move, and keeps the human in charge." />
-  <meta property="og:image" content="./goodkiddo-og-image.jpeg" />
+  <meta property="og:image" content="https://whosagoodkiddo.me/goodkiddo-og-image.jpeg" />
+  <meta property="og:image:secure_url" content="https://whosagoodkiddo.me/goodkiddo-og-image.jpeg" />
   <meta property="og:image:type" content="image/jpeg" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
   <meta property="og:image:alt" content="GoodKiddo mascot fetching one safe next move from a Telegram chat." />
+  <meta property="og:logo" content="https://whosagoodkiddo.me/kiddo-logo.jpg" />
   <link rel="preload" as="image" href="./goodkiddo-og-image.jpeg" />
+  <link rel="preload" as="image" href="./src/kiddo-logo.jpg" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="GoodKiddo — Fetch one safe next move in Telegram" />
   <meta name="twitter:description" content="GoodKiddo is a friendly business dog in Telegram that watches messy chats, prepares one useful next move, and keeps the human in charge." />
-  <meta name="twitter:image" content="./goodkiddo-og-image.jpeg" />
+  <meta name="twitter:image" content="https://whosagoodkiddo.me/goodkiddo-og-image.jpeg" />
   <meta name="twitter:image:alt" content="GoodKiddo mascot fetching one safe next move from a Telegram chat." />
   <link rel="icon" href="./public/favicon.ico" sizes="any">
   <link rel="apple-touch-icon" href="./apple-touch-icon.png">

--- a/web/index.html
+++ b/web/index.html
@@ -16,16 +16,18 @@
 <meta property="og:url" content="https://app.whosagoodkiddo.me/fs/" />
 <meta property="og:title" content="GoodKiddo Workspace — Shared files from Telegram" />
 <meta property="og:description" content="Open scoped GoodKiddo files from Telegram: preview, browse, and download only what was shared." />
-<meta property="og:image" content="./goodkiddo-web-og-image.jpeg" />
+<meta property="og:image" content="https://app.whosagoodkiddo.me/fs/goodkiddo-web-og-image.jpeg" />
+<meta property="og:image:secure_url" content="https://app.whosagoodkiddo.me/fs/goodkiddo-web-og-image.jpeg" />
 <meta property="og:image:type" content="image/jpeg" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
 <meta property="og:image:alt" content="GoodKiddo mascot guarding a scoped shared-file workspace preview." />
+<meta property="og:logo" content="https://whosagoodkiddo.me/kiddo-logo.jpg" />
 <link rel="preload" as="image" href="./goodkiddo-web-og-image.jpeg" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="GoodKiddo Workspace — Shared files from Telegram" />
 <meta name="twitter:description" content="Open scoped GoodKiddo files from Telegram: preview, browse, and download only what was shared." />
-<meta name="twitter:image" content="./goodkiddo-web-og-image.jpeg" />
+<meta name="twitter:image" content="https://app.whosagoodkiddo.me/fs/goodkiddo-web-og-image.jpeg" />
 <meta name="twitter:image:alt" content="GoodKiddo mascot guarding a scoped shared-file workspace preview." />
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add a `sharp`-based `bun run images:optimize` / `bun run images:check` workflow
- optimize checked-in landing and web image assets
- add nginx cache headers for generated scripts, styles, images, and fonts
- document image optimization and static cache behavior

## Verification
- bun run images:check
- bun run landing:build
- bun run web:build

Note: nginx is not installed in this local environment, so I could not run `nginx -t` against the rendered template locally.