### PR TITLE
[codex] Add Telegram error diagnostics

### DIFF
--- a/bot/src/channels/telegram/handlers.ts
+++ b/bot/src/channels/telegram/handlers.ts
@@ -22,6 +22,10 @@ import {
 	isImageMimeType,
 	processTelegramFile,
 } from "./files";
+import {
+	errorFieldsForLog,
+	summarizeTelegramUpdateForLog,
+} from "./logging";
 import { sendTelegramMessage, TelegramOutboundChannel } from "./outbound";
 import { ensureTelegramSession } from "./session";
 import {
@@ -470,8 +474,8 @@ export const telegramChannel: AppChannel = {
 		bot.catch(async (error) => {
 			const err = error.error;
 			log.error("bot error", {
-				error: err instanceof Error ? err.message : String(err),
-				updateId: error.ctx?.update?.update_id,
+				...errorFieldsForLog(err),
+				...summarizeTelegramUpdateForLog(error.ctx?.update),
 			});
 		});
 

--- a/bot/src/channels/telegram/logging.test.ts
+++ b/bot/src/channels/telegram/logging.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import {
+	errorFieldsForLog,
+	summarizeTelegramUpdateForLog,
+} from "./logging";
+
+describe("telegram logging helpers", () => {
+	test("errorFieldsForLog includes Error stack and SQL-style metadata", () => {
+		const error = Object.assign(new Error("integer out of range"), {
+			code: "22003",
+			table: "harness_users",
+			column: "created_at",
+			detail: "value exceeds integer range",
+		});
+
+		expect(errorFieldsForLog(error)).toMatchObject({
+			error: "integer out of range",
+			errorName: "Error",
+			errorCode: "22003",
+			errorTable: "harness_users",
+			errorColumn: "created_at",
+			errorDetail: "value exceeds integer range",
+		});
+		expect(errorFieldsForLog(error).errorStack).toContain(
+			"integer out of range",
+		);
+	});
+
+	test("summarizeTelegramUpdateForLog captures text message metadata without content", () => {
+		const summary = summarizeTelegramUpdateForLog({
+			update_id: 135030354,
+			message: {
+				message_id: 77,
+				date: 1778222935,
+				text: "private message content",
+				chat: { id: 123456, type: "private" },
+				from: { id: 999 },
+			},
+		});
+
+		expect(summary).toEqual({
+			updateId: 135030354,
+			updateType: "message",
+			chatId: "123456",
+			chatType: "private",
+			fromId: "999",
+			messageId: 77,
+			messageDate: 1778222935,
+			textLength: 23,
+			messageKind: "text",
+		});
+		expect(Object.values(summary)).not.toContain("private message content");
+	});
+
+	test("summarizeTelegramUpdateForLog captures callback metadata with truncated data", () => {
+		const summary = summarizeTelegramUpdateForLog({
+			update_id: 42,
+			callback_query: {
+				id: "callback-1",
+				data: "approve-once:prompt-id-with-long-suffix",
+				from: { id: 555 },
+				message: {
+					message_id: 12,
+					date: 1778222935,
+					chat: { id: -100123, type: "supergroup" },
+				},
+			},
+		});
+
+		expect(summary).toMatchObject({
+			updateId: 42,
+			updateType: "callback_query",
+			callbackQueryId: "callback-1",
+			callbackDataLength: 39,
+			callbackDataPrefix: "approve-once:prompt-id-with-long",
+			fromId: "555",
+			chatId: "-100123",
+			chatType: "supergroup",
+			messageId: 12,
+			messageDate: 1778222935,
+		});
+	});
+});

--- a/bot/src/channels/telegram/logging.ts
+++ b/bot/src/channels/telegram/logging.ts
@@ -1,0 +1,173 @@
+const ERROR_META_KEYS = [
+	"code",
+	"errno",
+	"detail",
+	"hint",
+	"where",
+	"schema",
+	"table",
+	"column",
+	"constraint",
+	"severity",
+	"routine",
+] as const;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	return typeof value === "object" && value !== null
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+function primitive(value: unknown): string | number | boolean | null | undefined {
+	if (
+		typeof value === "string" ||
+		typeof value === "number" ||
+		typeof value === "boolean" ||
+		value === null ||
+		value === undefined
+	) {
+		return value;
+	}
+	return undefined;
+}
+
+function capitalize(value: string): string {
+	return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+export function errorFieldsForLog(error: unknown): Record<string, unknown> {
+	const fields: Record<string, unknown> = {};
+	if (error instanceof Error) {
+		fields.error = error.message;
+		fields.errorName = error.name;
+		fields.errorStack = error.stack;
+		if (error.cause !== undefined) {
+			fields.errorCause =
+				error.cause instanceof Error ? error.cause.message : String(error.cause);
+		}
+	} else {
+		fields.error = String(error);
+	}
+
+	const record = asRecord(error);
+	if (!record) return fields;
+
+	for (const key of ERROR_META_KEYS) {
+		const value = primitive(record[key]);
+		if (value !== undefined) {
+			fields[`error${capitalize(key)}`] = value;
+		}
+	}
+	return fields;
+}
+
+function idField(value: unknown): string | undefined {
+	if (typeof value === "number" || typeof value === "string") {
+		return String(value);
+	}
+	return undefined;
+}
+
+function stringLength(value: unknown): number | undefined {
+	return typeof value === "string" ? value.length : undefined;
+}
+
+function firstPresentKey(
+	record: Record<string, unknown>,
+	keys: readonly string[],
+): string | undefined {
+	return keys.find((key) => record[key] !== undefined);
+}
+
+function setField(
+	fields: Record<string, unknown>,
+	key: string,
+	value: unknown,
+): void {
+	if (value !== undefined) fields[key] = value;
+}
+
+function summarizeMessage(
+	message: Record<string, unknown> | null,
+	fields: Record<string, unknown>,
+): void {
+	if (!message) return;
+
+	const chat = asRecord(message.chat);
+	const from = asRecord(message.from);
+	setField(fields, "chatId", idField(chat?.id));
+	setField(fields, "chatType", primitive(chat?.type));
+	setField(fields, "fromId", idField(from?.id));
+	setField(fields, "messageId", primitive(message.message_id));
+	setField(fields, "messageDate", primitive(message.date));
+	setField(fields, "textLength", stringLength(message.text));
+	setField(fields, "captionLength", stringLength(message.caption));
+
+	const messageKind = firstPresentKey(message, [
+		"text",
+		"photo",
+		"voice",
+		"document",
+		"audio",
+		"video",
+		"sticker",
+		"location",
+	]);
+	setField(fields, "messageKind", messageKind);
+
+	const document = asRecord(message.document);
+	if (document) {
+		setField(fields, "documentFileName", primitive(document.file_name));
+		setField(fields, "documentMimeType", primitive(document.mime_type));
+		setField(fields, "documentFileSize", primitive(document.file_size));
+	}
+
+	const voice = asRecord(message.voice);
+	if (voice) {
+		setField(fields, "voiceFileSize", primitive(voice.file_size));
+		setField(fields, "voiceDuration", primitive(voice.duration));
+	}
+
+	if (Array.isArray(message.photo)) {
+		fields.photoCount = message.photo.length;
+	}
+}
+
+export function summarizeTelegramUpdateForLog(
+	update: unknown,
+): Record<string, unknown> {
+	const fields: Record<string, unknown> = {};
+	const record = asRecord(update);
+	if (!record) return fields;
+
+	setField(fields, "updateId", primitive(record.update_id));
+	const updateType = firstPresentKey(record, [
+		"message",
+		"edited_message",
+		"callback_query",
+		"channel_post",
+		"edited_channel_post",
+	]);
+	setField(fields, "updateType", updateType);
+
+	if (updateType === "callback_query") {
+		const callback = asRecord(record.callback_query);
+		setField(fields, "callbackQueryId", idField(callback?.id));
+		setField(fields, "callbackDataLength", stringLength(callback?.data));
+		if (typeof callback?.data === "string") {
+			fields.callbackDataPrefix = callback.data.slice(0, 32);
+		}
+		setField(fields, "fromId", idField(asRecord(callback?.from)?.id));
+		summarizeMessage(asRecord(callback?.message), fields);
+		return fields;
+	}
+
+	summarizeMessage(
+		asRecord(record.message) ??
+			asRecord(record.edited_message) ??
+			asRecord(record.channel_post) ??
+			asRecord(record.edited_channel_post),
+		fields,
+	);
+	return fields;
+}

--- a/bot/src/channels/telegram/turn.ts
+++ b/bot/src/channels/telegram/turn.ts
@@ -9,7 +9,7 @@ import type {
 import { persistAlwaysRule } from "../../permissions/approval";
 import { maybeHandleCommand } from "../../permissions/commands";
 import type { PermissionsStore } from "../../permissions/store";
-import type { Caller } from "../../permissions/types";
+import type { Caller, UserRecord } from "../../permissions/types";
 import { maybeHandleSessionCommand } from "../session_commands";
 import {
 	clearPendingTaskCheckContext,
@@ -19,6 +19,7 @@ import {
 } from "../shared";
 import type { ChannelRunOptions } from "../types";
 import { applyTelegramAttachmentBudget } from "./attachment";
+import { errorFieldsForLog } from "./logging";
 import { escapeTelegramHtml } from "./markdown";
 import { sendTelegramMessage, startTelegramTypingLoop } from "./outbound";
 import {
@@ -166,7 +167,18 @@ export async function getTelegramCaller(
 	store: PermissionsStore,
 	chatId: string,
 ): Promise<{ caller: Caller; isNew: boolean } | null> {
-	const user = await store.getUser("telegram", chatId);
+	let user: UserRecord | null;
+	try {
+		user = await store.getUser("telegram", chatId);
+	} catch (error) {
+		log.error("telegram caller lookup failed", {
+			stage: "getUser",
+			chatId,
+			callerId: `telegram:${chatId}`,
+			...errorFieldsForLog(error),
+		});
+		throw error;
+	}
 	if (user) {
 		if (user.status === "suspended") return null;
 		return {
@@ -179,12 +191,36 @@ export async function getTelegramCaller(
 			isNew: false,
 		};
 	}
-	await store.createUserFree({
-		entrypoint: "telegram",
-		externalId: chatId,
-	});
+	const createdAtMs = Date.now();
+	try {
+		await store.createUserFree({
+			entrypoint: "telegram",
+			externalId: chatId,
+		});
+	} catch (error) {
+		log.error("telegram caller auto-create failed", {
+			stage: "createUserFree",
+			chatId,
+			callerId: `telegram:${chatId}`,
+			createdAtMs,
+			createdAtIso: new Date(createdAtMs).toISOString(),
+			...errorFieldsForLog(error),
+		});
+		throw error;
+	}
 	trackUserCreated(chatId, "telegram");
-	const newUser = await store.getUser("telegram", chatId);
+	let newUser: UserRecord | null;
+	try {
+		newUser = await store.getUser("telegram", chatId);
+	} catch (error) {
+		log.error("telegram caller lookup failed", {
+			stage: "getUserAfterCreate",
+			chatId,
+			callerId: `telegram:${chatId}`,
+			...errorFieldsForLog(error),
+		});
+		throw error;
+	}
 	if (!newUser) return null;
 	return {
 		caller: {


### PR DESCRIPTION
## Summary

- Expand Telegram `bot.catch` logging with structured error metadata, including SQL-style fields such as code, table, column, and detail when available.
- Add sanitized Telegram update summaries with IDs, message/update type, timestamps, and content lengths without logging raw message text.
- Add targeted logs around Telegram caller lookup and auto-create failures so production errors identify the failing stage.

## Impact

This makes the production `integer out of range` class of failures easier to attribute without adding schema changes or logging private user message content.

## Validation

- `bun test bot/src/channels/telegram/logging.test.ts bot/src/channels/telegram.test.ts`
- `bunx biome check bot/src/channels/telegram/logging.ts bot/src/channels/telegram/logging.test.ts bot/src/channels/telegram/handlers.ts bot/src/channels/telegram/turn.ts`
- `git diff --check`