### PR TITLE
[codex] Fix Postgres timestamp column widths

### DIFF
--- a/bot/src/README.md
+++ b/bot/src/README.md
@@ -21,3 +21,8 @@ Source root for the harness.
 - `guest/` — runner that executes inside the sandbox
 - `identities/` — system prompts
 - `utils/` — small shared helpers
+
+PostgreSQL stores that persist millisecond timestamps from `Date.now()` use
+`BIGINT` columns. Store initialization also migrates older Postgres timestamp
+columns from `INTEGER` to `BIGINT` so production tables can accept current
+epoch-millisecond values.

--- a/bot/src/capabilities/timers/store.ts
+++ b/bot/src/capabilities/timers/store.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { ensurePostgresBigintColumn } from "../../db/postgres_bigint_columns";
 import { createLogger } from "../../logger";
 
 const log = createLogger("timers.store");
@@ -157,6 +158,9 @@ export class TimerStore {
 
 	private async migrateTimerColumns(): Promise<void> {
 		if (this.dialect === "postgres") {
+			await ensurePostgresBigintColumn(this.db, "timers", "last_run_at");
+			await ensurePostgresBigintColumn(this.db, "timers", "next_run_at");
+			await ensurePostgresBigintColumn(this.db, "timers", "created_at");
 			await this.db`
 				ALTER TABLE timers
 				ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT 'always'

--- a/bot/src/db/postgres_bigint_columns.ts
+++ b/bot/src/db/postgres_bigint_columns.ts
@@ -1,0 +1,57 @@
+type SQL = InstanceType<typeof Bun.SQL>;
+
+const ALLOWED_BIGINT_COLUMNS = {
+	harness_users: ["created_at"],
+	fs_access_grants: ["expires_at", "created_at", "revoked_at"],
+	tasks: ["created_at", "updated_at", "completed_at", "dismissed_at"],
+	timers: ["last_run_at", "next_run_at", "created_at"],
+} as const;
+
+export type PostgresBigintTable = keyof typeof ALLOWED_BIGINT_COLUMNS;
+export type PostgresBigintColumn =
+	(typeof ALLOWED_BIGINT_COLUMNS)[PostgresBigintTable][number];
+
+type ColumnTypeRow = {
+	data_type: string;
+	udt_name: string;
+};
+
+function assertAllowedColumn(
+	table: PostgresBigintTable,
+	column: PostgresBigintColumn,
+): void {
+	if (
+		!(
+			ALLOWED_BIGINT_COLUMNS[table] as readonly PostgresBigintColumn[]
+		).includes(column)
+	) {
+		throw new Error(`Unexpected BIGINT migration target ${table}.${column}`);
+	}
+}
+
+function quoteIdentifier(identifier: string): string {
+	return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+export async function ensurePostgresBigintColumn(
+	db: SQL,
+	table: PostgresBigintTable,
+	column: PostgresBigintColumn,
+): Promise<void> {
+	assertAllowedColumn(table, column);
+
+	const rows = await db<ColumnTypeRow[]>`
+		SELECT data_type, udt_name
+		FROM information_schema.columns
+		WHERE table_schema = current_schema()
+			AND table_name = ${table}
+			AND column_name = ${column}
+	`;
+	const type = rows[0];
+	if (type && (type.data_type === "bigint" || type.udt_name === "int8")) return;
+
+	await db.unsafe(`
+		ALTER TABLE ${quoteIdentifier(table)}
+		ALTER COLUMN ${quoteIdentifier(column)} TYPE BIGINT
+	`);
+}

--- a/bot/src/db/postgres_schema.test.ts
+++ b/bot/src/db/postgres_schema.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { TimerStore } from "../capabilities/timers/store";
+import { ensurePostgresBigintColumn } from "./postgres_bigint_columns";
+import { PermissionsStore } from "../permissions/store";
+import { AccessStore } from "../server/access_store";
+import { TaskStore } from "../tasks/store";
+
+type SQL = InstanceType<typeof Bun.SQL>;
+
+function expectBigintMigration(sql: string, column: string): void {
+	expect(sql).toContain(`ALTER COLUMN "${column}" TYPE BIGINT`);
+}
+
+function createRecordingDb(options?: {
+	columnTypeRows?: Array<{ data_type: string; udt_name: string }>;
+}): { db: SQL; statements: string[] } {
+	const statements: string[] = [];
+	const db = ((
+		strings: TemplateStringsArray,
+		..._values: unknown[]
+	): Promise<unknown[]> => {
+		const statement = strings.join("?");
+		statements.push(statement);
+		if (statement.includes("information_schema.columns")) {
+			return Promise.resolve(options?.columnTypeRows ?? []);
+		}
+		return Promise.resolve([]);
+	}) as unknown as SQL & { unsafe: (query: string) => Promise<unknown[]> };
+	db.unsafe = (query: string): Promise<unknown[]> => {
+		statements.push(query);
+		return Promise.resolve([]);
+	};
+	return { db, statements };
+}
+
+describe("Postgres schema", () => {
+	test("uses BIGINT for epoch-millisecond columns and migrates older integer columns", async () => {
+		const permissions = createRecordingDb();
+		const permissionsStore = new PermissionsStore({
+			db: permissions.db,
+			dialect: "postgres",
+		});
+		await permissionsStore.getUser("telegram", "1");
+
+		expect(permissions.statements.join("\n")).toContain(
+			"created_at BIGINT NOT NULL",
+		);
+		expectBigintMigration(permissions.statements.join("\n"), "created_at");
+
+		const access = createRecordingDb();
+		const accessStore = new AccessStore({
+			db: access.db,
+			dialect: "postgres",
+		});
+		await accessStore.listActive("telegram:1");
+
+		const accessSql = access.statements.join("\n");
+		expect(accessSql).toContain("expires_at BIGINT NOT NULL");
+		expect(accessSql).toContain("created_at BIGINT NOT NULL");
+		expect(accessSql).toContain("revoked_at BIGINT");
+		expectBigintMigration(accessSql, "expires_at");
+		expectBigintMigration(accessSql, "created_at");
+		expectBigintMigration(accessSql, "revoked_at");
+
+		const tasks = createRecordingDb();
+		const taskStore = new TaskStore({ db: tasks.db, dialect: "postgres" });
+		await taskStore.ready();
+
+		const taskSql = tasks.statements.join("\n");
+		expect(taskSql).toContain("created_at BIGINT NOT NULL");
+		expect(taskSql).toContain("updated_at BIGINT NOT NULL");
+		expect(taskSql).toContain("completed_at BIGINT");
+		expect(taskSql).toContain("dismissed_at BIGINT");
+		expectBigintMigration(taskSql, "created_at");
+		expectBigintMigration(taskSql, "updated_at");
+		expectBigintMigration(taskSql, "completed_at");
+		expectBigintMigration(taskSql, "dismissed_at");
+
+		const timers = createRecordingDb();
+		const timerStore = new TimerStore({ db: timers.db, dialect: "postgres" });
+		await timerStore.ready();
+
+		const timerSql = timers.statements.join("\n");
+		expect(timerSql).toContain("last_run_at BIGINT");
+		expect(timerSql).toContain("next_run_at BIGINT NOT NULL");
+		expect(timerSql).toContain("created_at BIGINT NOT NULL");
+		expectBigintMigration(timerSql, "last_run_at");
+		expectBigintMigration(timerSql, "next_run_at");
+		expectBigintMigration(timerSql, "created_at");
+	});
+
+	test("does not issue BIGINT DDL when Postgres column is already bigint", async () => {
+		const { db, statements } = createRecordingDb({
+			columnTypeRows: [{ data_type: "bigint", udt_name: "int8" }],
+		});
+
+		await ensurePostgresBigintColumn(db, "harness_users", "created_at");
+
+		const sql = statements.join("\n");
+		expect(sql).toContain("information_schema.columns");
+		expect(sql).not.toContain("ALTER TABLE");
+	});
+});

--- a/bot/src/permissions/README.md
+++ b/bot/src/permissions/README.md
@@ -1,6 +1,6 @@
 # permissions
 
-Multi-tenant tool permissions. Per-user rules in SQLite, default decision is `allow`, except `execute_*` tools which default to `ask`.
+Multi-tenant tool permissions. Per-user rules in SQLite/PostgreSQL, default decision is `allow`, except `execute_*` tools which default to `ask`.
 
 Users have two independent attributes: `tier` (free/paid) and `status` (active/suspended). Tier controls commercial account level; status controls access. A free user can be suspended, and a paid user can be suspended.
 
@@ -12,3 +12,8 @@ Users have two independent attributes: `tier` (free/paid) and `status` (active/s
 - `commands.ts` — `/policy /allow /deny /ask /reset` for self-service rule management
 
 Usage: instantiate `PermissionsStore`, hand it to the broker + tool guard, route slash-commands via `maybeHandleCommand` before invoking the agent.
+
+PostgreSQL user records store `created_at` as `BIGINT` because the value is an
+epoch-millisecond timestamp from `Date.now()`. `PermissionsStore` startup
+migrates older Postgres `harness_users.created_at` columns from `INTEGER` to
+`BIGINT`.

--- a/bot/src/permissions/store.ts
+++ b/bot/src/permissions/store.ts
@@ -1,4 +1,5 @@
 import { normalizeMatcher } from "./matcher";
+import { ensurePostgresBigintColumn } from "../db/postgres_bigint_columns";
 import {
 	type ArgumentMatcher,
 	type Caller,
@@ -79,20 +80,21 @@ export class PermissionsStore {
 
 	private async _init(): Promise<void> {
 		const db = this.database;
-		await db`
-      CREATE TABLE IF NOT EXISTS harness_users (
-        id TEXT PRIMARY KEY,
-        entrypoint TEXT NOT NULL,
-        external_id TEXT NOT NULL,
-        display_name TEXT,
-        tier TEXT NOT NULL DEFAULT 'paid',
-        status TEXT NOT NULL DEFAULT 'active',
-        created_at INTEGER NOT NULL,
-        identity_id TEXT,
-        UNIQUE(entrypoint, external_id)
-      )
-    `;
 		if (this.dialect === "postgres") {
+			await db`
+        CREATE TABLE IF NOT EXISTS harness_users (
+          id TEXT PRIMARY KEY,
+          entrypoint TEXT NOT NULL,
+          external_id TEXT NOT NULL,
+          display_name TEXT,
+          tier TEXT NOT NULL DEFAULT 'paid',
+          status TEXT NOT NULL DEFAULT 'active',
+          created_at BIGINT NOT NULL,
+          identity_id TEXT,
+          UNIQUE(entrypoint, external_id)
+        )
+      `;
+			await ensurePostgresBigintColumn(db, "harness_users", "created_at");
 			await db`
         CREATE TABLE IF NOT EXISTS tool_permissions (
           id SERIAL PRIMARY KEY,
@@ -104,6 +106,19 @@ export class PermissionsStore {
         )
       `;
 		} else {
+			await db`
+        CREATE TABLE IF NOT EXISTS harness_users (
+          id TEXT PRIMARY KEY,
+          entrypoint TEXT NOT NULL,
+          external_id TEXT NOT NULL,
+          display_name TEXT,
+          tier TEXT NOT NULL DEFAULT 'paid',
+          status TEXT NOT NULL DEFAULT 'active',
+          created_at INTEGER NOT NULL,
+          identity_id TEXT,
+          UNIQUE(entrypoint, external_id)
+        )
+      `;
 			await db`
         CREATE TABLE IF NOT EXISTS tool_permissions (
           id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/bot/src/server/access_store.ts
+++ b/bot/src/server/access_store.ts
@@ -1,5 +1,6 @@
 import { randomBytes, randomUUID } from "node:crypto";
 import { normalizePath } from "../backends/state_backend";
+import { ensurePostgresBigintColumn } from "../db/postgres_bigint_columns";
 
 type SQL = InstanceType<typeof Bun.SQL>;
 
@@ -83,18 +84,36 @@ export class AccessStore {
 
 	private async _init(): Promise<void> {
 		const db = this.database;
-		await db`
-      CREATE TABLE IF NOT EXISTS fs_access_grants (
-        link_uuid TEXT PRIMARY KEY,
-        bearer_token TEXT NOT NULL UNIQUE,
-        user_id TEXT NOT NULL,
-        scope_path TEXT NOT NULL,
-        scope_kind TEXT NOT NULL,
-        expires_at INTEGER NOT NULL,
-        created_at INTEGER NOT NULL,
-        revoked_at INTEGER
-      )
-    `;
+		if (this.dialect === "postgres") {
+			await db`
+        CREATE TABLE IF NOT EXISTS fs_access_grants (
+          link_uuid TEXT PRIMARY KEY,
+          bearer_token TEXT NOT NULL UNIQUE,
+          user_id TEXT NOT NULL,
+          scope_path TEXT NOT NULL,
+          scope_kind TEXT NOT NULL,
+          expires_at BIGINT NOT NULL,
+          created_at BIGINT NOT NULL,
+          revoked_at BIGINT
+        )
+      `;
+			await ensurePostgresBigintColumn(db, "fs_access_grants", "expires_at");
+			await ensurePostgresBigintColumn(db, "fs_access_grants", "created_at");
+			await ensurePostgresBigintColumn(db, "fs_access_grants", "revoked_at");
+		} else {
+			await db`
+        CREATE TABLE IF NOT EXISTS fs_access_grants (
+          link_uuid TEXT PRIMARY KEY,
+          bearer_token TEXT NOT NULL UNIQUE,
+          user_id TEXT NOT NULL,
+          scope_path TEXT NOT NULL,
+          scope_kind TEXT NOT NULL,
+          expires_at INTEGER NOT NULL,
+          created_at INTEGER NOT NULL,
+          revoked_at INTEGER
+        )
+      `;
+		}
 		await db`
       CREATE INDEX IF NOT EXISTS idx_fs_access_grants_user ON fs_access_grants(user_id)
     `;

--- a/bot/src/tasks/store.ts
+++ b/bot/src/tasks/store.ts
@@ -1,3 +1,4 @@
+import { ensurePostgresBigintColumn } from "../db/postgres_bigint_columns";
 import { createLogger } from "../logger";
 import { compactInline } from "../utils/text";
 
@@ -183,6 +184,8 @@ export class TaskStore {
 			`;
 		}
 
+		await this.migrateTimestampColumns();
+
 		await this.db`
 			CREATE INDEX IF NOT EXISTS idx_tasks_user_status_updated_at
 			ON tasks(user_id, status, updated_at DESC)
@@ -195,6 +198,15 @@ export class TaskStore {
 		if (this.dialect === "sqlite") {
 			await this.db`PRAGMA journal_mode = WAL`;
 		}
+	}
+
+	private async migrateTimestampColumns(): Promise<void> {
+		if (this.dialect !== "postgres") return;
+
+		await ensurePostgresBigintColumn(this.db, "tasks", "created_at");
+		await ensurePostgresBigintColumn(this.db, "tasks", "updated_at");
+		await ensurePostgresBigintColumn(this.db, "tasks", "completed_at");
+		await ensurePostgresBigintColumn(this.db, "tasks", "dismissed_at");
 	}
 
 	async ready(): Promise<void> {


### PR DESCRIPTION
## Summary
- Store Postgres epoch-millisecond timestamp columns as BIGINT for permissions/access grants.
- Add startup checks that widen older Postgres timestamp columns from INTEGER to BIGINT only when Postgres reports they are not already BIGINT.
- Add a schema regression test and docs for Postgres timestamp storage.

## Root Cause
Telegram auto-create inserts `harness_users.created_at` from `Date.now()`. Current epoch-millisecond values exceed Postgres `INTEGER` range, producing SQLSTATE `22003` (`integer out of range`).

## Runtime Behavior
On Postgres, store initialization creates missing tables, checks `information_schema.columns` for the known epoch-millisecond columns, and only issues `ALTER TABLE ... TYPE BIGINT` for columns that are not already `bigint`. It does not run the DDL on every Telegram update.

## Validation
- `bun test bot/src/db/postgres_schema.test.ts bot/src/permissions/store.test.ts bot/src/server/access_store.test.ts bot/src/tasks/store.test.ts bot/src/capabilities/timers/store.test.ts`
- `bunx biome check bot/src/db/postgres_bigint_columns.ts bot/src/db/postgres_schema.test.ts bot/src/permissions/store.ts bot/src/server/access_store.ts bot/src/tasks/store.ts bot/src/capabilities/timers/store.ts`
- `git diff --check`
- `bun run --filter goodkiddo-bot test`