### PR TITLE
[codex] Add landing CI deployment

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -1,0 +1,86 @@
+name: Deploy Landing
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "landing/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-landing-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build and deploy landing
+    runs-on: ubuntu-latest
+    env:
+      LANDING_REMOTE_DIR: /opt/goodkiddo/app/landing/dist
+      LANDING_REMOTE_USER: ubuntu
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build landing
+        run: bun run landing:build
+
+      - name: Prepare SSH
+        env:
+          DEPLOY_HOST: ${{ secrets.HOST }}
+          DEPLOY_KEY: ${{ secrets.KEY }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${DEPLOY_HOST}" ]]; then
+            echo "::error::Missing required HOST repository secret."
+            exit 1
+          fi
+
+          if [[ -z "${DEPLOY_KEY}" ]]; then
+            echo "::error::Missing required KEY repository secret."
+            exit 1
+          fi
+
+          if [[ "${DEPLOY_HOST}" == *@* ]]; then
+            echo "::error::HOST must be only the host or IP address. The workflow connects as ubuntu."
+            exit 1
+          fi
+
+          mkdir -p "${HOME}/.ssh"
+          chmod 700 "${HOME}/.ssh"
+
+          printf "%s\n" "${DEPLOY_KEY}" > "${RUNNER_TEMP}/landing_deploy_key"
+          chmod 600 "${RUNNER_TEMP}/landing_deploy_key"
+
+          ssh-keyscan -H "${DEPLOY_HOST}" >> "${HOME}/.ssh/known_hosts"
+          chmod 600 "${HOME}/.ssh/known_hosts"
+
+      - name: Deploy landing dist
+        env:
+          DEPLOY_HOST: ${{ secrets.HOST }}
+        run: |
+          set -euo pipefail
+          remote="${LANDING_REMOTE_USER}@${DEPLOY_HOST}"
+          remote_tmp="/tmp/goodkiddo-landing-dist-${GITHUB_SHA}"
+
+          ssh -i "${RUNNER_TEMP}/landing_deploy_key" "${remote}" \
+            "rm -rf '${remote_tmp}' && mkdir -p '${remote_tmp}'"
+
+          rsync -az --delete --delay-updates \
+            -e "ssh -i ${RUNNER_TEMP}/landing_deploy_key" \
+            landing/dist/ "${remote}:${remote_tmp}/"
+
+          ssh -i "${RUNNER_TEMP}/landing_deploy_key" "${remote}" \
+            "sudo mkdir -p '${LANDING_REMOTE_DIR}' && sudo rsync -a --delete '${remote_tmp}/' '${LANDING_REMOTE_DIR}/' && sudo chown -R goodkiddo:goodkiddo '${LANDING_REMOTE_DIR}' && rm -rf '${remote_tmp}'"

--- a/ops/README.md
+++ b/ops/README.md
@@ -115,6 +115,31 @@ Vault file and installs `uvx` so the runtime can launch
      /usr/local/bin/bun src/bin/admin.ts add-user telegram <chat-id> "Display name"
    ```
 
+## Landing CI Deployment
+
+The landing site can be deployed by GitHub Actions after production has been
+provisioned once with Ansible. The workflow in
+`.github/workflows/deploy-landing.yml` runs on pushes to `main` when any file
+under `landing/` changes, builds `landing/dist/` in CI, and rsyncs the built
+artifact to the nginx-served directory:
+
+```text
+/opt/goodkiddo/app/landing/dist
+```
+
+Configure these repository secrets before enabling the workflow:
+
+- `HOST`: SSH host or IP address, without a username
+- `KEY`: private SSH key for the `ubuntu` user on that host
+
+The workflow connects as `ubuntu`, uploads the built files to a temporary
+directory, then uses passwordless `sudo rsync` to mirror them into
+`/opt/goodkiddo/app/landing/dist`. The tracked Ansible defaults make
+`/opt/goodkiddo/app` owned by the `goodkiddo` service user, so the workflow
+restores `goodkiddo:goodkiddo` ownership after deployment. The playbook installs
+`rsync` on the host because the deployment workflow uses it to mirror deleted
+files as well as new and changed files.
+
 ## Notes
 
 - The playbook expects Ubuntu with `apt`.

--- a/ops/ansible/tasks/packages.yml
+++ b/ops/ansible/tasks/packages.yml
@@ -27,6 +27,7 @@
       - docker-compose
       - docker.io
       - nginx
+      - rsync
       - unzip
     state: present
     update_cache: true


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow that builds `landing/dist` when `landing/**` changes on `main`.
- Connect to the deployment host as `ubuntu` using the `HOST` and `KEY` repository secrets, upload artifacts to `/tmp`, then use passwordless `sudo rsync` into `/opt/goodkiddo/app/landing/dist`.
- Document the required secrets and install `rsync` through Ansible so the remote side of deployment is available after provisioning.
## Validation

- `bun run landing:build`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/deploy-landing.yml`
- `ruby -e 'require "yaml"; %w[.github/workflows/deploy-landing.yml ops/ansible/tasks/packages.yml].each { |f| YAML.load_file(f); puts "#{f} parses" }'`
- `git diff --check`
