### PR TITLE
[codex] Use production environment for landing deploy

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -18,6 +18,7 @@ jobs:
   deploy:
     name: Build and deploy landing
     runs-on: ubuntu-latest
+    environment: production
     env:
       LANDING_REMOTE_DIR: /opt/goodkiddo/app/landing/dist
       LANDING_REMOTE_USER: ubuntu
@@ -44,12 +45,12 @@ jobs:
           set -euo pipefail
 
           if [[ -z "${DEPLOY_HOST}" ]]; then
-            echo "::error::Missing required HOST repository secret."
+            echo "::error::Missing required HOST secret in the production environment."
             exit 1
           fi
 
           if [[ -z "${DEPLOY_KEY}" ]]; then
-            echo "::error::Missing required KEY repository secret."
+            echo "::error::Missing required KEY secret in the production environment."
             exit 1
           fi
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -8,6 +8,7 @@
   <meta name="description" content="GoodKiddo is a friendly business dog in Telegram that watches messy chats, prepares one useful next move, and keeps the human in charge." />
   <meta name="theme-color" content="#f4f1e8" />
   <meta name="application-name" content="GoodKiddo" />
+  <!-- Landing deploy smoke test marker. -->
   <meta name="apple-mobile-web-app-title" content="GoodKiddo" />
   <link rel="canonical" href="https://whosagoodkiddo.me/" />
   <meta property="og:type" content="website" />

--- a/ops/README.md
+++ b/ops/README.md
@@ -127,7 +127,8 @@ artifact to the nginx-served directory:
 /opt/goodkiddo/app/landing/dist
 ```
 
-Configure these repository secrets before enabling the workflow:
+The deployment job uses the GitHub Actions `production` environment. Configure
+these environment secrets before enabling the workflow:
 
 - `HOST`: SSH host or IP address, without a username
 - `KEY`: private SSH key for the `ubuntu` user on that host


### PR DESCRIPTION
## Summary

- Set the landing deploy job to use the GitHub Actions `production` environment, so `HOST` and `KEY` can be provided as environment secrets.
- Update the deploy error messages and ops docs to point at `production` environment secrets.
- Add a single invisible landing HTML comment as a smoke-test change so merging this PR exercises the deploy trigger.
## Validation

- `bun run landing:build`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/deploy-landing.yml`
- `ruby -e 'require "yaml"; %w[.github/workflows/deploy-landing.yml ops/ansible/tasks/packages.yml].each { |f| YAML.load_file(f); puts "#{f} parses" }'`
- `git diff --check`
