### PR TITLE
feat(landing): add not-a-crm fetch demo

### DIFF
--- a/landing/src/landing-page.jsx
+++ b/landing/src/landing-page.jsx
@@ -8,6 +8,7 @@ import HeroPiecePhoneImage from './hero-piece-phone.png';
 import HeroStickerBubbleImage from './hero-sticker-bubble.png';
 import HeroStickerBurstImage from './hero-sticker-burst.png';
 import HeroStickerCloudImage from './hero-sticker-cloud.png';
+import { NotCrmFetchDemo } from './not-crm-fetch-demo';
 
 const TELEGRAM_URL = 'https://t.me/goodkiddo_bot';
 const GITHUB_URL = 'https://github.com/KlonD90/goodkiddo';
@@ -451,6 +452,7 @@ function LandingPage() {
     <main className="gk-page overflow-x-hidden w-full max-w-full">
       <Nav />
       <Hero />
+      <NotCrmFetchDemo />
       <Systems />
       <UseCases />
       <Values />

--- a/landing/src/not-crm-fetch-demo.jsx
+++ b/landing/src/not-crm-fetch-demo.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+
+const demos = [
+  {
+    title: 'Stale quote / missed follow-up',
+    mess: 'Client asked for updated price on Monday. Team said “will send later”. Nothing happened.',
+    fetch: [
+      'Found promised quote was not sent',
+      'Prepared reply draft',
+      'Missing final price/date',
+    ],
+  },
+  {
+    title: 'Buried delivery/date question',
+    mess: 'Customer asked whether delivery can arrive Friday; team discussed warehouse but no one answered.',
+    fetch: [
+      'Found unanswered delivery question',
+      'Missing warehouse confirmation',
+      'Prepared safe checking reply',
+    ],
+  },
+  {
+    title: 'Complaint recovery',
+    mess: 'Driver crashed, parcel damaged, customer angry.',
+    fetch: [
+      'Facts checklist: order ID, photos, driver report, delivery time, damage description',
+      'Prepared calm reply',
+      'Boundary: no refund/liability promise until facts confirmed',
+    ],
+  },
+];
+
+function FetchDemoCard({ demo, index }) {
+  return (
+    <article className="gk-fetch-demo-card">
+      <div className="gk-fetch-demo-mess">
+        <span className="gk-fetch-demo-label">Mess {String(index + 1).padStart(2, '0')}</span>
+        <h3>{demo.title}</h3>
+        <p>{demo.mess}</p>
+      </div>
+      <div className="gk-fetch-demo-arrow" aria-hidden="true">→</div>
+      <div className="gk-fetch-card" aria-label={`${demo.title} Fetch Card`}>
+        <div className="gk-fetch-card-topline">
+          <span>GoodKiddo Fetch Card</span>
+          <strong>Telegram</strong>
+        </div>
+        <ul>
+          {demo.fetch.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </div>
+    </article>
+  );
+}
+
+function NotCrmFetchDemo() {
+  return (
+    <section className="gk-section gk-not-crm-demo" aria-labelledby="not-crm-fetch-demo-title">
+      <div className="gk-section-heading gk-section-heading-row">
+        <div>
+          <p className="gk-kicker">Not a CRM</p>
+          <h2 id="not-crm-fetch-demo-title">The dog just noticed what the CRM usually misses.</h2>
+        </div>
+        <p>
+          CRMs organize pipelines. GoodKiddo fetches one usable draft, checklist, or missing question from the chat — compact enough to use, edit, or ignore.
+        </p>
+      </div>
+
+      <div className="gk-fetch-demo-grid" aria-label="Messy Telegram business situations turned into Fetch Cards">
+        {demos.map((demo, index) => (
+          <FetchDemoCard demo={demo} index={index} key={demo.title} />
+        ))}
+      </div>
+
+      <div className="gk-fetch-demo-cta">
+        Send one messy Telegram business situation. GoodKiddo will fetch one draft, checklist, or missing question. No setup. If it’s wrong, it’s just text.
+      </div>
+    </section>
+  );
+}
+
+export { NotCrmFetchDemo };

--- a/landing/src/style.css
+++ b/landing/src/style.css
@@ -2402,6 +2402,144 @@ a {
   color: var(--muted);
 }
 
+.gk-not-crm-demo {
+  padding-top: 44px;
+}
+
+.gk-fetch-demo-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.gk-fetch-demo-card {
+  min-height: 100%;
+  padding: 16px;
+  display: grid;
+  grid-template-rows: minmax(148px, auto) 32px 1fr;
+  gap: 12px;
+  border: 1px solid rgba(16, 20, 18, 0.14);
+  border-radius: 12px;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(42, 171, 238, 0.1), transparent 34%),
+    rgba(255, 250, 240, 0.86);
+  box-shadow: 0 18px 44px rgba(16, 20, 18, 0.07);
+}
+
+.gk-fetch-demo-mess,
+.gk-fetch-card {
+  border: 1px solid rgba(16, 20, 18, 0.12);
+  border-radius: 18px;
+  box-shadow: 0 8px 20px rgba(16, 20, 18, 0.07);
+}
+
+.gk-fetch-demo-mess {
+  padding: 16px;
+  color: #162638;
+  background:
+    radial-gradient(circle at 18px 18px, rgba(16, 20, 18, 0.04) 0 2px, transparent 3px),
+    #dfeaf4;
+  background-size: 36px 36px;
+}
+
+.gk-fetch-demo-label,
+.gk-fetch-card-topline {
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  font-weight: 800;
+  line-height: 1.35;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.gk-fetch-demo-label {
+  color: var(--blue);
+}
+
+.gk-fetch-demo-mess h3 {
+  margin: 8px 0 0;
+  font-size: 1.36rem;
+  line-height: 1.05;
+  letter-spacing: 0;
+}
+
+.gk-fetch-demo-mess p {
+  margin: 10px 0 0;
+  color: rgba(22, 38, 56, 0.74);
+  font-size: 0.98rem;
+  font-weight: 700;
+  line-height: 1.38;
+}
+
+.gk-fetch-demo-arrow {
+  display: grid;
+  place-items: center;
+  color: var(--green);
+  font-size: 1.8rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.gk-fetch-card {
+  padding: 16px;
+  background: #fff;
+}
+
+.gk-fetch-card-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px dashed rgba(16, 20, 18, 0.18);
+  color: #28a774;
+}
+
+.gk-fetch-card-topline strong {
+  color: var(--blue);
+  font-size: 0.62rem;
+}
+
+.gk-fetch-card ul {
+  margin: 12px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 9px;
+  list-style: none;
+}
+
+.gk-fetch-card li {
+  position: relative;
+  padding-left: 22px;
+  color: var(--ink-soft);
+  font-size: 0.95rem;
+  line-height: 1.38;
+}
+
+.gk-fetch-card li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.42em;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.72);
+}
+
+.gk-fetch-demo-cta {
+  margin-top: 18px;
+  padding: 16px 18px;
+  border: 1px solid rgba(16, 20, 18, 0.14);
+  border-radius: 10px;
+  color: var(--ink);
+  background: rgba(220, 247, 232, 0.74);
+  font-size: 1.02rem;
+  font-weight: 760;
+  line-height: 1.45;
+}
+
 .gk-systems {
   padding-top: 78px;
 }
@@ -3476,6 +3614,16 @@ a {
     grid-template-rows: auto;
   }
 
+  .gk-fetch-demo-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .gk-fetch-demo-card {
+    grid-template-columns: minmax(0, 0.9fr) 36px minmax(0, 1fr);
+    grid-template-rows: auto;
+    align-items: stretch;
+  }
+
   .gk-safety-copy {
     grid-template-columns: 1fr;
     gap: 22px;
@@ -3771,6 +3919,15 @@ a {
   .gk-workflow,
   .gk-values-list {
     grid-template-columns: 1fr;
+  }
+
+  .gk-fetch-demo-card {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 30px auto;
+  }
+
+  .gk-fetch-demo-arrow {
+    transform: rotate(90deg);
   }
 
   .gk-signal-marquee {


### PR DESCRIPTION
## Summary
- Add a focused landing section: “Not a CRM / Fetch demo”.
- Show three messy Telegram business moments turning into compact GoodKiddo Fetch Cards:
  - stale quote / missed follow-up,
  - buried delivery/date question,
  - complaint recovery.
- Position GoodKiddo as draft/checklist/missing-question help for Telegram chats, not a CRM/dashboard/auto-send tool.

## Product rationale
Competitors in messenger CRM/agent space are converging on structured pipelines, team inboxes, CRM sync, and autonomous follow-up. This slice keeps GoodKiddo smaller and safer: it fetches one usable next-step artifact from messy Telegram context, then the human decides whether to use/edit/ignore it.

## Test plan
- [x] `PATH="$HOME/.bun/bin:$PATH" bun run landing:build`
- [x] `git diff --check origin/main...HEAD`
- [x] Confirmed PR diff is limited to landing UI files only.

## CI status
- GitHub `Tests` currently fails before landing checks in bot test baseline (`createDb` export removed / Prisma store tests failing).
- This is not introduced by this PR: the latest `main` CI run for `33835c5` (`Merge pull request #46 from KlonD90/codex/prisma-permissions`) is already failing: https://github.com/KlonD90/goodkiddo/actions/runs/25843259053

## Issue linkage
No open GitHub issues were applicable at PR creation time.
